### PR TITLE
feat(repo): add 7-day cooldown period for npm package releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
 		"enabled": true,
 		"automerge": true
 	},
+	"minimumReleaseAge": "7 days",
+	"internalChecksFilter": "strict",
+	"osvVulnerabilityAlerts": true,
+	"vulnerabilityAlerts": {
+		"minimumReleaseAge": null
+	},
 	"autoApprove": true,
 	"labels": ["Dependencies", "Renovate"],
 	"packageRules": [

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
 npmRegistryServer: 'https://registry.npmjs.org'
 enableGlobalCache: true
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
## Summary

npmサプライチェーン攻撃対策として、公開から **7日未満** のパッケージをインストール・更新対象から除外するクールダウン期間を設定します（[frontend-env#886](https://github.com/d-zero-dev/frontend-env/pull/886) の展開）。

- `.yarnrc.yml` に `npmMinimalAgeGate: 7d` を追加（Yarn 4.10.0+）
- `.github/renovate.json` に `minimumReleaseAge: "7 days"` および `internalChecksFilter: "strict"` を追加

## なぜ7日なのか

悪意あるパッケージの多くは公開から数時間〜数日以内に検出・削除されます。公開直後の短期間をブロックするだけで高い防御効果が得られます。

3日（Renovate の `config:best-practices` デフォルト）では防御期間として短く、14日以上は開発速度への影響が大きくなるため、**7日を採用しています**。Andrew Nesbitt も7日間のクールダウンの有効性について言及しています（[Package Managers Need to Cool Down](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html)）。

## 参考資料

- [Yarn: `npmMinimalAgeGate` configuration](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate)
- [Renovate: Minimum Release Age](https://docs.renovatebot.com/key-concepts/minimum-release-age/)
- [Package Managers Need to Cool Down (Andrew Nesbitt)](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html)

## 動作

| ツール | 動作 |
|---|---|
| Yarn | `yarn install` 時、公開7日未満のパッケージが含まれるとエラーで停止 |
| Renovate | 7日経過前はブランチ自体を作成しない（CVE対応のセキュリティ更新はバイパス） |

> [!WARNING]
> **Yarn 側には緊急時のバイパス手段がありません。**
> セキュリティパッチなど公開直後のパッケージをどうしても即座にインストールする必要がある場合は、`.yarnrc.yml` の `npmMinimalAgeGate` を一時的にコメントアウトして対応してください。
> 対応後は必ず元に戻してください。