### PR TITLE
feat(local): add Virtual File Tree mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,6 +154,22 @@ graph TD
   - `helpers/get-candidate-name.ts` - 候補ファイル名生成（EncodedFileName型エクスポート）
   - `helpers/upload.ts` - ファイルアップロード実装
   - `model/FileListManager` - 上記helpers関数を使用してアップロード処理を実装
+- **Virtual File Tree（仮想ファイルツリー）**:
+  - **何のための機能か**: `documentRoot` 配下を不透明な ID 名のフラットファイル群（`<id>.html`）として運用するプロジェクト向けに、Front Matter `path` から論理ツリーを再構築するオプトイン機能。外部 CMS 連携で命名権が無いケースを想定
+  - **既定挙動**: `virtualTree.enabled = false`。完全に従来の「ディスク階層 = エディタツリー」モード
+  - **設計判断**:
+    1. **disk と論理を完全分離** — disk は触らない。Front Matter の値だけが論理ツリーの真実。これにより「いつでもオプトアウトできる」可逆性を担保
+    2. **state の単一所有権** — モード分岐と `ResolverState` の保持は `route.tsx` 1 ファイルに閉じる。view / client は `virtualTreeEnabled` boolean しか知らない（疎結合）
+    3. **`withStateLock` でシリアライズ** — `let resolverState = ...` の read-modify-write を mutex で囲む。シングルユーザー編集前提だが、tab 二枚での並行更新で state 損失が起きないようにする保険
+    4. **2-phase commit** — `saveContent` 成功後にだけ state を進める。書き込み失敗時に state がディスクと乖離しない
+  - **構成ファイル**:
+    - `model/virtual-path-resolver.ts` - `ResolverState` 型と純関数群（`createEmptyState` / `loadResolverState` / `toDiskPath` / `toLogicalPath` / `listLogicalPaths` / `registerEntry` / `setLogicalPath` / `deleteEntry`）。`PathConflictError` と `IdAlreadyExistsError` のエラー語彙
+    - `model/file-tree.ts::buildFileTreeFromLogicalPaths` - 論理パス配列からツリー構造を組む純関数
+    - `route.tsx` - mode フラグの評価点。`GET /api/tree` / `POST /api/content/create` / `POST /api/content` の 3 エンドポイントが state を read-modify-write
+    - `view/app.tsx` / `view/nav.tsx` - SSR 時に `virtualTreeEnabled` prop を hidden input + Nav の入力欄出し分けで埋め込む
+    - `client/nav-tree.ts` - `/api/tree` を fetch して `#nav-tree-mount` をハイドレート
+    - `client/new-file.ts` - hidden input で flag を読み、有効時のみ ID 入力を必須化して `/api/content/create` を叩く
+  - **詳細ドキュメント**: [`packages/@burger-editor/local/docs/virtual-tree.md`](packages/@burger-editor/local/docs/virtual-tree.md)
 
 #### Support Layer（サポート層）
 

--- a/packages/@burger-editor/local/README.md
+++ b/packages/@burger-editor/local/README.md
@@ -30,10 +30,10 @@ npx bge
 yarn bge
 ```
 
-開発サーバーが起動したら、ブラウザで以下にアクセスしてください：
+開発サーバーが起動したら、ブラウザで以下にアクセスしてください（ポートは設定で上書き可能）：
 
 ```
-http://localhost:3000
+http://localhost:5255
 ```
 
 ### 検索コマンド
@@ -153,10 +153,10 @@ title: 'New Page'
 
 #### オプショナル設定
 
-- `version` (string): 設定ファイルのバージョン（デフォルト: パッケージバージョン）
-- `port` (number): サーバーのポート番号（デフォルト: 3000）
+- `version` (string): 設定ファイルのバージョン（デフォルト: `'0.0.0-unknown'`）
+- `port` (number): サーバーのポート番号（デフォルト: 5255）
 - `host` (string): ホスト名（デフォルト: 'localhost'）
-- `lang` (string): 言語設定（デフォルト: 'ja'）
+- `lang` (string): 言語設定（デフォルト: 'en'）
 - `stylesheets` (string[]): 読み込むスタイルシートのパス（デフォルト: []）
 - `classList` (string[]): ブロックに適用するCSSクラス（デフォルト: []）
 - `editableArea` (string | null): 編集可能エリアのセレクタ（デフォルト: null）
@@ -173,6 +173,9 @@ title: 'New Page'
   - `enabled` (boolean): ヘルスチェックを有効にする（デフォルト: true）
   - `interval` (number): チェック間隔（ミリ秒）（デフォルト: 10000）
   - `retryCount` (number): リトライ回数（デフォルト: 3）
+- `virtualTree` (object): 仮想ファイルツリー機能の設定（詳細は [Virtual File Tree](#virtual-file-tree仮想ファイルツリー) 参照）
+  - `enabled` (boolean): 有効化フラグ（デフォルト: false）
+  - `pathKey` (string): 論理パスとして読み取る Front Matter キー名（デフォルト: 'path'）
 
 ## Front Matter編集機能
 
@@ -219,6 +222,84 @@ published: true
 1. キー名を入力（例: `author`, `category`）
 2. 型を選択（テキスト、数値、真偽値、日付、JSON）
 3. 「追加」ボタンをクリック
+
+## Virtual File Tree（仮想ファイルツリー）
+
+外部 CMS と連携する際など、`documentRoot` 配下に **HTML ファイルがフラットな ID 名で並んでいる** プロジェクト向けに、Front Matter に書かれたパス情報からエディタ上の仮想ツリーを構築するオプトイン機能です。
+
+### 何が変わるか
+
+|                          | 通常モード（既定）       | 仮想モード（`virtualTree.enabled = true`）                   |
+| ------------------------ | ------------------------ | ------------------------------------------------------------ |
+| ディスク上のファイル配置 | ディレクトリ階層そのまま | フラット `<id>.html`（変更しない）                           |
+| エディタのファイルツリー | ディスク階層と同じ       | 各ファイルの `frontMatter[pathKey]` から再構築した仮想ツリー |
+| 新規ファイル作成         | パスを入力               | パスと **ID** の両方を入力                                   |
+| パス変更                 | ファイルを実際に移動     | Front Matter の path 値を書き換えるだけ（ディスク不変）      |
+| マイナーリリース互換性   | —                        | 既定 `enabled: false` で完全に従来挙動                       |
+
+### 採用前提
+
+仮想モードを有効化する前に、以下を必ず満たしてください。満たさないとサーバ起動時にエラーで停止します。
+
+1. `documentRoot` 直下の `*.html` がすべて Front Matter を持っている
+2. すべてのファイルの Front Matter に `pathKey`（既定 `path`）が文字列として存在する
+3. 同じ `pathKey` 値を持つファイルが複数存在しない
+
+### 設定例
+
+```js
+// burgereditor.config.js
+export default {
+	documentRoot: path.join(import.meta.dirname, 'src'),
+	assetsRoot: path.join(import.meta.dirname, 'public'),
+	editableArea: '.my-editor',
+	virtualTree: {
+		enabled: true,
+		// 既定は 'path'。プロジェクトのスタイルに合わせて 'slug' / 'route' などに変更可
+		pathKey: 'path',
+	},
+};
+```
+
+### 期待される Front Matter
+
+ファイル `documentRoot/42.html`（ファイル名 = ID）の内容:
+
+```text
+---
+path: company/about.html
+title: 会社概要
+---
+<div class="my-editor">…</div>
+```
+
+エディタは上記ファイルを `company/about.html` の位置にあるかのように表示します。Front Matter の `path` を編集して保存すると、仮想ツリーは即座に新しい位置に切り替わりますが、ディスク上のファイル名は `42.html` のまま変わりません。
+
+### 起動時に PathConflictError で停止したとき
+
+エラーメッセージに衝突した論理パスと、その論理パスを主張している複数のディスクファイルが列挙されます：
+
+```
+Conflicting logical paths in virtual tree:
+  - "about.html" claimed by: 1.html, 2.html
+```
+
+いずれか一方の Front Matter `path` を別の値に書き換えてからサーバを再起動してください。
+
+### 制約と既知の限界
+
+- 編集ダイアログから新規作成するときに **ID と論理パスの両方をユーザが手入力** する必要があります（ID 自動採番は未対応）
+- 同一の論理パスを複数ファイルに持たせることはできません
+- 論理パスは仮想ツリー内のキーとしてのみ使われ、ディスクパスには影響しません。`..` を含めても documentRoot からの脱出は起きませんが、編集 UI から開けない孤児ファイルになるため注意（[#755](https://github.com/d-zero-dev/BurgerEditor/issues/755) で UX 改善を予定）
+- 並行更新の整合性は内部 mutex で守られます（シングルユーザー編集前提）
+
+### 関連 issue
+
+- [#753](https://github.com/d-zero-dev/BurgerEditor/issues/753) `client/create-editor.ts` のエラーパステスト整備
+- [#754](https://github.com/d-zero-dev/BurgerEditor/issues/754) 起動失敗時の終了挙動テスト
+- [#755](https://github.com/d-zero-dev/BurgerEditor/issues/755) 論理パスのサニタイズ（`..` 拒否）
+
+詳細な採用手順とトラブルシュートは [`docs/virtual-tree.md`](./docs/virtual-tree.md) を参照してください。
 
 ## ブロックのコピー&ペースト
 

--- a/packages/@burger-editor/local/burgereditor.config.js
+++ b/packages/@burger-editor/local/burgereditor.config.js
@@ -51,6 +51,14 @@ title: 'New Page'
 		other: '/files/others',
 	},
 	open: true,
+	// Virtual File Tree（仮想ファイルツリー）
+	// documentRoot 配下を <id>.html のフラット運用にしつつ、Front Matter の path
+	// で論理ツリーを再構築するオプション。詳細は README.md / docs/virtual-tree.md。
+	// このローカル開発設定では既定どおり無効。
+	virtualTree: {
+		enabled: false,
+		pathKey: 'path',
+	},
 	// 実験的機能: アイテムオプションのカスタマイズ
 	experimental: {
 		itemOptions: {

--- a/packages/@burger-editor/local/docs/virtual-tree.md
+++ b/packages/@burger-editor/local/docs/virtual-tree.md
@@ -1,0 +1,164 @@
+# Virtual File Tree（仮想ファイルツリー）採用ガイド
+
+外部 CMS / ヘッドレス連携向けに、`documentRoot` 配下を「フラットな ID 名のファイル群」のまま運用しつつ、編集 UI 上では Front Matter の値からツリー構造を再構築するオプトイン機能。
+
+このドキュメントは「採用するかしないかの判断」「採用するなら何を準備するか」「失敗時の戻し方」を扱う。機能の API リファレンスは [README.md](../README.md#virtual-file-tree仮想ファイルツリー) を参照。
+
+---
+
+## いつ使うか
+
+以下のすべてに当てはまるプロジェクトで採用する。
+
+- 外部システム（CMS、独自ファイルサーバ、エクスポートパイプライン）が `<id>.html` のような不透明な ID 名でファイルを管理しており、その命名を変えられない
+- 編集者には「about ページ」「会社情報 / 沿革」のような直感的なパスでファイルを見せたい
+- 各ファイルの Front Matter に論理パスを書くフィールド（既定 `path`、変更可）が用意できる
+
+## いつ使わないか
+
+以下のいずれかに当てはまるプロジェクトでは採用しない。`virtualTree.enabled = false`（既定）のまま使う。
+
+- すでにディレクトリ構造で HTML を整理している（`pages/about/index.html` 等）。仮想ツリーに切り替える必然性がない
+- ファイル名が人間可読（`about.html`、`company.html` 等）で運用上問題ない
+- 同じ論理パスを複数のファイルに持たせたい、または論理パスがファイル間で衝突する可能性がある
+- 編集者に ID を意識させたくない（仮想モード時は新規作成ダイアログで ID 入力が必須）
+
+---
+
+## 採用前提
+
+仮想モードを有効化してサーバを起動するためには、`documentRoot` 直下の **すべての `*.html`** が以下を満たす必要がある。満たさないファイルが 1 つでもあれば起動が失敗する。
+
+1. Front Matter を持っている（`---` で囲まれた YAML ブロック）
+2. Front Matter に `pathKey`（既定 `path`）を **空でない文字列値** として持っている
+3. `pathKey` の値がプロジェクト内で **一意**（衝突したら起動拒否）
+
+例：
+
+```html
+---
+path: company/about.html
+title: 会社概要
+---
+
+<div class="my-editor">…</div>
+```
+
+---
+
+## 採用手順
+
+### 1. プロジェクトの状態を確認する
+
+```bash
+# documentRoot 直下の HTML 数を数える
+find <documentRoot> -maxdepth 1 -name '*.html' | wc -l
+
+# Front Matter を持たないファイルを洗い出す
+for f in <documentRoot>/*.html; do
+    head -1 "$f" | grep -q '^---$' || echo "no frontmatter: $f"
+done
+```
+
+### 2. 設定を有効化
+
+`burgereditor.config.js` に以下を追記。
+
+```js
+export default {
+	// ...既存の設定...
+	virtualTree: {
+		enabled: true,
+		pathKey: 'path', // プロジェクトで使うキー名
+	},
+};
+```
+
+### 3. 起動
+
+```bash
+yarn dev
+# または
+npx bge
+```
+
+成功すればブラウザでツリーが論理パスで表示される。失敗時は次節へ。
+
+### 4. オプトアウト（戻し方）
+
+ディスクは一切変更されないため、`virtualTree.enabled = false` に戻すだけでいつでも元の挙動に戻せる。再起動するとフラット ID のままディスク階層がツリーに反映される。
+
+---
+
+## 失敗パターンとリカバリ
+
+### `PathConflictError: Conflicting logical paths in virtual tree`
+
+複数のファイルが同じ論理パスを主張している。
+
+```
+Conflicting logical paths in virtual tree:
+  - "about.html" claimed by: 1.html, 2.html
+```
+
+**対処**: 列挙された 2 つ以上のファイルのうち、いずれか以外の Front Matter `path` を別の値に書き換えて再起動。
+
+### `Front matter "path" missing or not a string in <file>`
+
+該当ファイルに Front Matter がない、または `pathKey` の値が文字列でない（数値、`null`、配列、欠落）。
+
+**対処**: ファイルを開いて Front Matter を追加または修正。
+
+```html
+---
+path: some/logical/path.html
+---
+```
+
+### `IdAlreadyExistsError: File ID "<id>" is already in use`
+
+新規作成 API が叩かれたが、その ID は既にディスクに存在している。クライアントの入力ミスがほとんど。
+
+実際のメッセージには末尾に `(currently mapped to "<logical-path>")` が付き、その ID が現在どの論理パスで運用されているかを示す。重複していたファイルの所在をそこから辿れる。
+
+**対処**: 新規作成ダイアログで重複しない ID を再入力する。
+
+### `400 Resolved path escapes documentRoot`
+
+ID やパスに `..`、`/`、`\` などのパス区切り / トラバーサル試行が含まれている（[セキュリティ修正済み](../README.md#virtual-file-tree仮想ファイルツリー)）。
+
+**対処**: ID には以下を含めない。
+
+- パス区切り `/` および `\`
+- NUL 文字 `\0`
+- `.`（ドット 1 つ）あるいは `..`（ドット 2 つ）そのもの
+- 先頭が `.` で始まる文字列（dotfile）
+
+それ以外の文字は許可されますが、ファイル名としての安全性を考えると英数字・アンダースコア・ハイフン・ドット（先頭以外）に絞るのが無難です。
+
+---
+
+## トラブルシュート
+
+### 仮想ツリーに登録したはずのファイルが UI から開けない
+
+論理パス（Front Matter の `path`）に `..` や絶対パス風の値が含まれていないか確認する。論理パスはディスクへ届かないので脱出はしないが、ブラウザのリンク正規化で別 URL に飛ばされるため UI から開けなくなる。詳細は [#755](https://github.com/d-zero-dev/BurgerEditor/issues/755)。
+
+### 起動失敗のメッセージが Stack Trace に埋もれる
+
+現状は uncaught exception として Node が出力する。専用の整形は [#754](https://github.com/d-zero-dev/BurgerEditor/issues/754) で対応予定。当面はメッセージの最初の数行（`Error: ...` の直後）のみを読めば原因が特定できる。
+
+---
+
+## 参考リンク
+
+- [README.md の Virtual File Tree セクション](../README.md#virtual-file-tree仮想ファイルツリー) — API リファレンス
+- [#753](https://github.com/d-zero-dev/BurgerEditor/issues/753) — `client/create-editor.ts` のテスト整備
+- [#754](https://github.com/d-zero-dev/BurgerEditor/issues/754) — 起動失敗時の出口テスト
+- [#755](https://github.com/d-zero-dev/BurgerEditor/issues/755) — 論理パスのサニタイズ
+- [gray-matter](https://github.com/jonschlinkert/gray-matter) — 内部で使っている Front Matter パーサ
+- 検索キーワード: `BurgerEditor virtualTree` / `PathConflictError` / `IdAlreadyExistsError` / `@burger-editor/local frontmatter path`
+
+## このドキュメントの更新責任
+
+`@burger-editor/local` のメンテナ。仮想ツリー機能の挙動を変更したら同時にこのドキュメントを更新する。RC 期間中の仕様変更は自由。安定リリース後はマイグレーションパスをここに追記する。

--- a/packages/@burger-editor/local/src/client/create-editor.ts
+++ b/packages/@burger-editor/local/src/client/create-editor.ts
@@ -91,10 +91,19 @@ export async function createEditor() {
 			},
 		});
 
-		const json = await res.json();
-		if (!json.saved) {
+		if (!res.ok) {
+			const errorBody = (await res.json().catch(() => ({}))) as {
+				error?: string;
+			};
 			// eslint-disable-next-line no-console
-			console.error(`Failed to save: ${json.path}`);
+			console.error(`Failed to save: ${errorBody.error ?? res.statusText}`);
+			return;
+		}
+
+		const json = await res.json();
+		if (!('saved' in json) || !json.saved) {
+			// eslint-disable-next-line no-console
+			console.error('Save did not complete');
 			return;
 		}
 

--- a/packages/@burger-editor/local/src/client/index.ts
+++ b/packages/@burger-editor/local/src/client/index.ts
@@ -1,4 +1,5 @@
 import { createEditor } from './create-editor.js';
+import { hydrateNavTree } from './nav-tree.js';
 import { newFile } from './new-file.js';
 
 await Promise.all([
@@ -7,4 +8,7 @@ await Promise.all([
 
 	// Define commands for buttons
 	newFile(),
+
+	// Populate the file tree from the server's logical view
+	hydrateNavTree(),
 ]);

--- a/packages/@burger-editor/local/src/client/nav-tree.spec.ts
+++ b/packages/@burger-editor/local/src/client/nav-tree.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { hydrateNavTree } from './nav-tree.js';
+
+describe('hydrateNavTree', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '<div id="nav-tree-mount"></div>';
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test('does nothing when the mount point is missing', async () => {
+		document.body.innerHTML = '';
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		await hydrateNavTree();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	test('renders <a class="file"> for files and <span class="dir"> for directories', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			Response.json(
+				{
+					tree: [
+						{ name: 'about.html', path: '/about.html' },
+						{
+							name: 'foo',
+							path: '/foo',
+							files: [{ name: 'bar.html', path: '/foo/bar.html' }],
+						},
+					],
+				},
+				{ status: 200, headers: { 'content-type': 'application/json' } },
+			),
+		);
+
+		await hydrateNavTree();
+
+		const mount = document.getElementById('nav-tree-mount');
+		expect(mount).not.toBeNull();
+
+		const fileLinks = mount!.querySelectorAll('a.file');
+		expect([...fileLinks].map((a) => a.getAttribute('href'))).toEqual([
+			'/about.html',
+			'/foo/bar.html',
+		]);
+
+		const dirSpans = mount!.querySelectorAll('span.dir');
+		expect([...dirSpans].map((s) => s.textContent)).toEqual(['foo']);
+	});
+
+	test('rejects (does not silently swallow) when fetch fails — caller decides recovery', async () => {
+		vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+		await expect(hydrateNavTree()).rejects.toThrow(/network down/);
+		// Mount stays empty; no children appended on failure.
+		const mount = document.getElementById('nav-tree-mount');
+		expect(mount?.childNodes.length ?? 0).toBe(0);
+	});
+
+	test('replaces previous children on re-hydrate (idempotent)', async () => {
+		const mount = document.getElementById('nav-tree-mount')!;
+		mount.append(document.createElement('p'));
+
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			Response.json(
+				{
+					tree: [{ name: 'index.html', path: '/index.html' }],
+				},
+				{ status: 200, headers: { 'content-type': 'application/json' } },
+			),
+		);
+
+		await hydrateNavTree();
+
+		expect(mount.querySelectorAll('p')).toHaveLength(0);
+		expect(mount.querySelectorAll('a.file')).toHaveLength(1);
+	});
+});

--- a/packages/@burger-editor/local/src/client/nav-tree.ts
+++ b/packages/@burger-editor/local/src/client/nav-tree.ts
@@ -1,0 +1,62 @@
+import type { Tree } from '../model/file-tree.js';
+import type { AppType } from '../route.js';
+
+import { hc } from 'hono/client';
+
+const client = hc<AppType>(location.origin);
+
+/**
+ * Fetch the file tree JSON from the server (`GET /api/tree`) and render it
+ * into the `#nav-tree-mount` placeholder produced by `view/nav.tsx`.
+ *
+ * The server decides whether the response represents the on-disk directory
+ * tree or the logical (virtualTree) tree, so this client code is agnostic to
+ * the mode. Safe to call multiple times — re-renders idempotently.
+ *
+ * Errors from the network or response parsing are propagated to the caller
+ * (i.e. not silently swallowed) so that boot-time failures are visible.
+ * @returns A promise that resolves once the tree has been rendered. Resolves
+ *          with no value when the mount point is absent.
+ */
+export async function hydrateNavTree() {
+	const mount = document.getElementById('nav-tree-mount');
+	if (!mount) {
+		return;
+	}
+
+	const res = await client.api.tree.$get();
+	const { tree } = await res.json();
+
+	mount.replaceChildren(buildList(tree));
+}
+
+/**
+ * Build a `<ul>` DOM subtree mirroring the SSR output of `view/nav-tree.tsx`.
+ * @param items the tree returned by `GET /api/tree`
+ * @returns a `<ul>` element ready to be appended into the DOM
+ */
+function buildList(items: Tree): HTMLUListElement {
+	const ul = document.createElement('ul');
+	for (const item of items) {
+		const li = document.createElement('li');
+		if (item.name.endsWith('.html')) {
+			const a = document.createElement('a');
+			a.className = 'file';
+			a.href = item.path;
+			const span = document.createElement('span');
+			span.textContent = item.name;
+			a.append(span);
+			li.append(a);
+		} else {
+			const span = document.createElement('span');
+			span.className = 'dir';
+			span.textContent = item.name;
+			li.append(span);
+		}
+		if ('files' in item) {
+			li.append(buildList(item.files));
+		}
+		ul.append(li);
+	}
+	return ul;
+}

--- a/packages/@burger-editor/local/src/client/new-file.spec.ts
+++ b/packages/@burger-editor/local/src/client/new-file.spec.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { newFile } from './new-file.js';
+
+type CapturedRequest = { url: string; init: RequestInit | undefined };
+
+/**
+ *
+ * @param virtualTreeEnabled
+ */
+function setupForm(virtualTreeEnabled: boolean): HTMLFormElement {
+	document.body.innerHTML = `
+		<input type="hidden" id="virtual-tree-enabled" value="${virtualTreeEnabled}" />
+		<form id="new-file-form" method="dialog">
+			<label><span>File path</span><input type="text" name="path" /></label>
+			${virtualTreeEnabled ? '<label><span>File ID</span><input type="text" name="id" /></label>' : ''}
+		</form>
+	`;
+	return document.getElementById('new-file-form') as HTMLFormElement;
+}
+
+describe('newFile (virtualTree disabled)', () => {
+	const navigate = vi.fn<(url: string) => void>();
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		navigate.mockReset();
+		fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response('{}', { status: 200 }));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test('navigates to /<path>.html on submit without calling the create API', async () => {
+		const form = setupForm(false);
+		(form.elements.namedItem('path') as HTMLInputElement).value = 'foo/bar';
+		newFile(navigate);
+
+		form.dispatchEvent(new Event('submit', { cancelable: true }));
+		await vi.waitFor(() => {
+			expect(navigate).toHaveBeenCalledExactlyOnceWith('/foo/bar.html');
+		});
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	test('strips leading slash and parent traversal segments from the path', async () => {
+		const form = setupForm(false);
+		(form.elements.namedItem('path') as HTMLInputElement).value = '/../foo/bar.html';
+		newFile(navigate);
+
+		form.dispatchEvent(new Event('submit', { cancelable: true }));
+		await vi.waitFor(() => {
+			expect(navigate).toHaveBeenCalledExactlyOnceWith('/foo/bar.html');
+		});
+	});
+
+	test('does not navigate when path is empty', async () => {
+		const form = setupForm(false);
+		(form.elements.namedItem('path') as HTMLInputElement).value = '';
+		newFile(navigate);
+
+		form.dispatchEvent(new Event('submit', { cancelable: true }));
+		// Give the async submit handler a chance to run.
+		await new Promise((r) => setTimeout(r, 20));
+		expect(navigate).not.toHaveBeenCalled();
+	});
+});
+
+describe('newFile (virtualTree enabled)', () => {
+	const navigate = vi.fn<(url: string) => void>();
+	const fetchCalls: CapturedRequest[] = [];
+	let alertSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		navigate.mockReset();
+		fetchCalls.length = 0;
+		alertSpy = vi
+			.spyOn(globalThis, 'alert')
+			.mockImplementation(() => undefined as unknown as void);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	/**
+	 *
+	 * @param status
+	 * @param body
+	 */
+	function mockCreateApi(status: number, body: unknown = {}) {
+		vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+			const url = typeof input === 'string' ? input : (input as Request).url;
+			fetchCalls.push({ url, init });
+			return Promise.resolve(
+				Response.json(body, {
+					status,
+					headers: { 'content-type': 'application/json' },
+				}),
+			);
+		});
+	}
+
+	test('alerts and stays put when id is empty', async () => {
+		const form = setupForm(true);
+		(form.elements.namedItem('path') as HTMLInputElement).value = 'about.html';
+		(form.elements.namedItem('id') as HTMLInputElement).value = '';
+		mockCreateApi(200);
+		newFile(navigate);
+
+		form.dispatchEvent(new Event('submit', { cancelable: true }));
+		await vi.waitFor(() => {
+			expect(alertSpy).toHaveBeenCalledTimes(1);
+		});
+		expect(fetchCalls).toHaveLength(0);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	test('POSTs id and path to /api/content/create and navigates on success', async () => {
+		const form = setupForm(true);
+		(form.elements.namedItem('path') as HTMLInputElement).value = 'foo/about';
+		(form.elements.namedItem('id') as HTMLInputElement).value = '42';
+		mockCreateApi(200);
+		newFile(navigate);
+
+		form.dispatchEvent(new Event('submit', { cancelable: true }));
+		await vi.waitFor(() => {
+			expect(navigate).toHaveBeenCalledExactlyOnceWith('/foo/about.html');
+		});
+
+		expect(fetchCalls).toHaveLength(1);
+		expect(fetchCalls[0]?.url).toMatch(/\/api\/content\/create$/);
+		const body = JSON.parse(String(fetchCalls[0]?.init?.body)) as Record<string, string>;
+		expect(body).toEqual({ id: '42', path: 'foo/about.html' });
+	});
+
+	test('alerts the server error message and does not navigate when create fails', async () => {
+		const form = setupForm(true);
+		(form.elements.namedItem('path') as HTMLInputElement).value = 'about.html';
+		(form.elements.namedItem('id') as HTMLInputElement).value = '5.html';
+		mockCreateApi(409, {
+			error: 'File ID "5.html" is already in use (currently mapped to "about.html").',
+		});
+		newFile(navigate);
+
+		form.dispatchEvent(new Event('submit', { cancelable: true }));
+		await vi.waitFor(() => {
+			expect(alertSpy).toHaveBeenCalledTimes(1);
+		});
+
+		expect(alertSpy).toHaveBeenCalledWith(
+			expect.stringMatching(/File ID "5\.html" is already in use/),
+		);
+		expect(navigate).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@burger-editor/local/src/client/new-file.ts
+++ b/packages/@burger-editor/local/src/client/new-file.ts
@@ -1,11 +1,34 @@
+import type { AppType } from '../route.js';
+
+import { hc } from 'hono/client';
+
+const client = hc<AppType>(location.origin);
+
+type Navigate = (url: string) => void;
+
+const defaultNavigate: Navigate = (url) => {
+	globalThis.location.href = url;
+};
+
 /**
+ * Wires up the "new file" dialog. Behaviour depends on whether the server is
+ * running in virtualTree mode — that flag is rendered into the DOM by the SSR
+ * layer (see `view/app.tsx`) so we don't pay an extra fetch on every page.
  *
+ * `navigate` is exposed for tests; in production we just assign to
+ * `globalThis.location.href`.
+ * @param navigate
  */
-export function newFile() {
+export function newFile(navigate: Navigate = defaultNavigate): void {
 	const form = document.getElementById('new-file-form');
 	if (!form) {
 		return;
 	}
+
+	const flagEl = document.getElementById(
+		'virtual-tree-enabled',
+	) as HTMLInputElement | null;
+	const virtualTreeEnabled = flagEl?.value === 'true';
 
 	form.addEventListener('submit', async (e) => {
 		e.preventDefault();
@@ -24,6 +47,26 @@ export function newFile() {
 			savePath += '.html';
 		}
 
-		globalThis.location.href = `/${savePath}`;
+		if (virtualTreeEnabled) {
+			const idData = formData.get('id');
+			const id = typeof idData === 'string' ? idData.trim() : '';
+			if (id === '') {
+				alert('File ID is required when virtualTree is enabled.');
+				return;
+			}
+			const res = await client.api.content.create.$post({
+				json: { id, path: savePath },
+			});
+			if (!res.ok) {
+				const body = (await res.json().catch(() => ({}))) as {
+					error?: string;
+				};
+
+				alert(body.error ?? `Failed to create file (status ${res.status})`);
+				return;
+			}
+		}
+
+		navigate(`/${savePath}`);
 	});
 }

--- a/packages/@burger-editor/local/src/commands/server.ts
+++ b/packages/@burger-editor/local/src/commands/server.ts
@@ -7,10 +7,20 @@ import open from 'open';
 
 import { log } from '../helpers/debug.js';
 import { getUserConfig } from '../model/get-user-config.js';
+import { loadResolverState } from '../model/virtual-path-resolver.js';
 import { setRoute } from '../route.js';
 
 /**
+ * Boot the local BurgerEditor server. Reads the user config via cosmiconfig,
+ * pre-loads the virtualTree resolver state if enabled, mounts the Hono routes,
+ * and prints a banner.
  *
+ * If `virtualTree.enabled` is true and the documentRoot contains files that
+ * violate the virtualTree contract (missing `pathKey`, non-string value, or
+ * conflicting logical paths), this throws synchronously before the HTTP server
+ * binds, so process startup fails loudly instead of serving a broken state.
+ * @returns A promise that resolves once the banner has been printed. The HTTP
+ *          server keeps running afterwards and is not awaited here.
  */
 export async function runServerCommand(): Promise<void> {
 	const app = new Hono();
@@ -18,7 +28,11 @@ export async function runServerCommand(): Promise<void> {
 
 	const isWatchMode = process.env.DEV_MODE === 'true';
 
-	setRoute(app, userConfig);
+	const resolverState = userConfig.virtualTree.enabled
+		? await loadResolverState(userConfig.documentRoot, userConfig.virtualTree.pathKey)
+		: null;
+
+	setRoute(app, userConfig, resolverState);
 
 	serve({
 		fetch: app.fetch,

--- a/packages/@burger-editor/local/src/model/file-tree.spec.ts
+++ b/packages/@burger-editor/local/src/model/file-tree.spec.ts
@@ -1,0 +1,65 @@
+import type { DirInfo, FileInfo } from './file-tree.js';
+
+import { describe, expect, test } from 'vitest';
+
+import { buildFileTreeFromLogicalPaths } from './file-tree.js';
+
+describe('buildFileTreeFromLogicalPaths', () => {
+	test('returns empty tree for empty input', () => {
+		expect(buildFileTreeFromLogicalPaths([])).toEqual([]);
+	});
+
+	test('builds a single FileInfo for a top-level path', () => {
+		const tree = buildFileTreeFromLogicalPaths(['about.html']);
+		expect(tree).toHaveLength(1);
+		const node = tree[0] as FileInfo;
+		expect(node.name).toBe('about.html');
+		expect(node.path).toBe('/about.html');
+		expect('files' in node).toBe(false);
+	});
+
+	test('builds nested DirInfo structure for nested path', () => {
+		const tree = buildFileTreeFromLogicalPaths(['foo/bar/about.html']);
+		expect(tree).toHaveLength(1);
+		const foo = tree[0] as DirInfo;
+		expect(foo.name).toBe('foo');
+		expect(foo.path).toBe('/foo');
+		expect(foo.files).toHaveLength(1);
+
+		const bar = foo.files[0] as DirInfo;
+		expect(bar.name).toBe('bar');
+		expect(bar.path).toBe('/foo/bar');
+		expect(bar.files).toHaveLength(1);
+
+		const file = bar.files[0] as FileInfo;
+		expect(file.name).toBe('about.html');
+		expect(file.path).toBe('/foo/bar/about.html');
+	});
+
+	test('groups siblings under shared directories', () => {
+		const tree = buildFileTreeFromLogicalPaths([
+			'foo/a.html',
+			'foo/b.html',
+			'bar/c.html',
+		]);
+		const map = Object.fromEntries(tree.map((node) => [node.name, node]));
+		expect(Object.keys(map).toSorted()).toEqual(['bar', 'foo']);
+		const foo = map.foo as DirInfo;
+		expect(foo.files.map((f) => f.name).toSorted()).toEqual(['a.html', 'b.html']);
+		const bar = map.bar as DirInfo;
+		expect(bar.files.map((f) => f.name)).toEqual(['c.html']);
+	});
+
+	test('handles a mix of top-level files and nested files', () => {
+		const tree = buildFileTreeFromLogicalPaths(['index.html', 'foo/a.html']);
+		const names = tree.map((node) => node.name).toSorted();
+		expect(names).toEqual(['foo', 'index.html']);
+	});
+
+	test('tolerates leading slash in logical paths', () => {
+		const tree = buildFileTreeFromLogicalPaths(['/foo/a.html']);
+		const foo = tree[0] as DirInfo;
+		expect(foo.name).toBe('foo');
+		expect(foo.files[0]?.name).toBe('a.html');
+	});
+});

--- a/packages/@burger-editor/local/src/model/file-tree.ts
+++ b/packages/@burger-editor/local/src/model/file-tree.ts
@@ -1,23 +1,28 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+/** A single file entry in a navigation tree. `path` is rooted with a leading slash. */
 export type FileInfo = {
 	readonly name: string;
 	readonly path: string;
 };
 
+/** A directory entry containing a recursive subtree. */
 export type DirInfo = {
 	readonly name: string;
 	readonly path: string;
 	readonly files: Tree;
 };
 
+/** Ordered list of file or directory entries forming a navigation tree. */
 export type Tree = readonly (FileInfo | DirInfo)[];
 
 /**
- *
- * @param dirPath
- * @param rootPath
+ * Walk a directory recursively and build a navigation tree of `*.html` files.
+ * Used in non-virtualTree mode to mirror the on-disk layout into the editor UI.
+ * @param dirPath the directory to scan
+ * @param rootPath the root used to compute each entry's `path` field; defaults to `dirPath` for top-level calls
+ * @returns a tree describing the directory structure
  */
 export async function generateFileTree(
 	dirPath: string,
@@ -53,4 +58,67 @@ export async function generateFileTree(
 	}
 
 	return tree;
+}
+
+type MutableDir = {
+	name: string;
+	path: string;
+	files: (FileInfo | MutableDir)[];
+};
+
+/**
+ * Recursively convert a mutable working node into the readonly `DirInfo`
+ * shape exposed by this module.
+ * @param dir the in-progress mutable directory built up by `buildFileTreeFromLogicalPaths`
+ * @returns a frozen `DirInfo` mirroring `dir`
+ */
+function freezeDir(dir: MutableDir): DirInfo {
+	return {
+		name: dir.name,
+		path: dir.path,
+		files: dir.files.map((entry) => ('files' in entry ? freezeDir(entry) : entry)),
+	};
+}
+
+/**
+ * Build a navigation tree from an unordered list of logical paths (e.g.
+ * `['about.html', 'foo/bar.html']`). Used in virtualTree mode where the disk
+ * is flat and the tree is reconstructed from Front Matter values.
+ *
+ * Leading slashes are tolerated; empty segments are skipped. Sibling order
+ * follows the input order of `logicalPaths`.
+ * @param logicalPaths logical paths to assemble into a tree
+ * @returns a tree mirroring the same shape as `generateFileTree` so the SSR/client view code can render it identically
+ */
+export function buildFileTreeFromLogicalPaths(logicalPaths: readonly string[]): Tree {
+	const root: MutableDir = { name: '', path: '/', files: [] };
+
+	for (const raw of logicalPaths) {
+		const segments = raw.split('/').filter((s) => s.length > 0);
+		if (segments.length === 0) {
+			continue;
+		}
+
+		let cursor = root;
+		for (let i = 0; i < segments.length - 1; i++) {
+			const segment = segments[i]!;
+			const dirPath = '/' + segments.slice(0, i + 1).join('/');
+			let next = cursor.files.find(
+				(entry): entry is MutableDir => 'files' in entry && entry.name === segment,
+			);
+			if (!next) {
+				next = { name: segment, path: dirPath, files: [] };
+				cursor.files.push(next);
+			}
+			cursor = next;
+		}
+
+		const fileName = segments.at(-1)!;
+		cursor.files.push({
+			name: fileName,
+			path: '/' + segments.join('/'),
+		});
+	}
+
+	return root.files.map((entry) => ('files' in entry ? freezeDir(entry) : entry));
 }

--- a/packages/@burger-editor/local/src/model/get-user-config.ts
+++ b/packages/@burger-editor/local/src/model/get-user-config.ts
@@ -14,7 +14,10 @@ import { cosmiconfig } from 'cosmiconfig';
 const explorer = cosmiconfig('burgereditor');
 
 /**
- *
+ * Locate and parse the user's BurgerEditor config (via cosmiconfig) and merge
+ * it with the package defaults. Missing fields are filled in with the values
+ * documented in `packages/@burger-editor/local/README.md`.
+ * @returns A fully resolved {@link LocalServerConfig} ready to feed into `setRoute`.
  */
 export async function getUserConfig(): Promise<LocalServerConfig> {
 	const res = await explorer.search();
@@ -56,6 +59,10 @@ export async function getUserConfig(): Promise<LocalServerConfig> {
 			...config.healthCheck,
 		},
 		experimental: config.experimental,
+		virtualTree: {
+			enabled: config.virtualTree?.enabled ?? false,
+			pathKey: config.virtualTree?.pathKey ?? 'path',
+		},
 	};
 }
 

--- a/packages/@burger-editor/local/src/model/virtual-path-resolver.spec.ts
+++ b/packages/@burger-editor/local/src/model/virtual-path-resolver.spec.ts
@@ -1,0 +1,274 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import {
+	IdAlreadyExistsError,
+	PathConflictError,
+	createEmptyState,
+	deleteEntry,
+	listLogicalPaths,
+	loadResolverState,
+	registerEntry,
+	setLogicalPath,
+	toDiskPath,
+	toLogicalPath,
+	type ResolverState,
+} from './virtual-path-resolver.js';
+
+/**
+ * Build a state by replaying registerEntry, so tests exercise the public API
+ * rather than depending on the internal Map shape.
+ * @param entries
+ */
+function makeState(
+	entries: readonly { id: string; logicalPath: string }[],
+): ResolverState {
+	let state = createEmptyState();
+	for (const { id, logicalPath } of entries) {
+		state = registerEntry(state, id, logicalPath);
+	}
+	return state;
+}
+
+describe('toDiskPath / toLogicalPath', () => {
+	const state = makeState([
+		{ id: '1.html', logicalPath: 'about.html' },
+		{ id: '2.html', logicalPath: 'foo/bar.html' },
+	]);
+
+	test('toDiskPath maps logical to disk', () => {
+		expect(toDiskPath(state, 'about.html')).toBe('1.html');
+		expect(toDiskPath(state, 'foo/bar.html')).toBe('2.html');
+	});
+
+	test('toDiskPath returns null for unknown logical path', () => {
+		expect(toDiskPath(state, 'missing.html')).toBeNull();
+	});
+
+	test('toLogicalPath maps disk to logical', () => {
+		expect(toLogicalPath(state, '1.html')).toBe('about.html');
+		expect(toLogicalPath(state, '2.html')).toBe('foo/bar.html');
+	});
+
+	test('toLogicalPath returns null for unknown disk file', () => {
+		expect(toLogicalPath(state, '99.html')).toBeNull();
+	});
+});
+
+describe('listLogicalPaths', () => {
+	test('returns all logical paths', () => {
+		const state = makeState([
+			{ id: '1.html', logicalPath: 'about.html' },
+			{ id: '2.html', logicalPath: 'foo/bar.html' },
+		]);
+		expect(listLogicalPaths(state).toSorted()).toEqual(['about.html', 'foo/bar.html']);
+	});
+
+	test('returns empty for empty state', () => {
+		expect(listLogicalPaths(makeState([]))).toEqual([]);
+	});
+});
+
+describe('registerEntry', () => {
+	test('adds a new entry and returns new state', () => {
+		const state = makeState([{ id: '1.html', logicalPath: 'about.html' }]);
+		const next = registerEntry(state, '2.html', 'foo/bar.html');
+		expect(toDiskPath(next, 'foo/bar.html')).toBe('2.html');
+		expect(toDiskPath(next, 'about.html')).toBe('1.html');
+		// original state must not be mutated
+		expect(toDiskPath(state, 'foo/bar.html')).toBeNull();
+	});
+
+	test('throws PathConflictError when logical path already taken, naming both ids', () => {
+		const state = makeState([{ id: '1.html', logicalPath: 'about.html' }]);
+		try {
+			registerEntry(state, '2.html', 'about.html');
+			throw new Error('expected throw');
+		} catch (error) {
+			expect(error).toBeInstanceOf(PathConflictError);
+			const conflicts = (error as PathConflictError).conflicts;
+			expect(conflicts).toEqual([
+				{ logicalPath: 'about.html', diskFiles: ['1.html', '2.html'] },
+			]);
+		}
+	});
+
+	test('throws IdAlreadyExistsError naming the requested id and its current logical path', () => {
+		const state = makeState([{ id: '1.html', logicalPath: 'about.html' }]);
+		try {
+			registerEntry(state, '1.html', 'other.html');
+			throw new Error('expected throw');
+		} catch (error) {
+			expect(error).toBeInstanceOf(IdAlreadyExistsError);
+			expect(error).not.toBeInstanceOf(PathConflictError);
+			const e = error as IdAlreadyExistsError;
+			expect(e.id).toBe('1.html');
+			expect(e.existingLogicalPath).toBe('about.html');
+			expect(e.message).toContain('1.html');
+			expect(e.message).toContain('about.html');
+		}
+	});
+});
+
+describe('setLogicalPath', () => {
+	test('updates logical path for existing id', () => {
+		const state = makeState([
+			{ id: '1.html', logicalPath: 'about.html' },
+			{ id: '2.html', logicalPath: 'foo/bar.html' },
+		]);
+		const next = setLogicalPath(state, '1.html', 'company/about.html');
+		expect(toDiskPath(next, 'company/about.html')).toBe('1.html');
+		expect(toDiskPath(next, 'about.html')).toBeNull();
+		expect(toLogicalPath(next, '1.html')).toBe('company/about.html');
+		// other entry unchanged
+		expect(toDiskPath(next, 'foo/bar.html')).toBe('2.html');
+	});
+
+	test('returns the same state reference when the path is unchanged (no-op fast path)', () => {
+		const state = makeState([{ id: '1.html', logicalPath: 'about.html' }]);
+		const next = setLogicalPath(state, '1.html', 'about.html');
+		expect(next).toBe(state);
+	});
+
+	test('throws Error (not PathConflictError) when id is unknown, with id in message', () => {
+		const state = makeState([{ id: '1.html', logicalPath: 'about.html' }]);
+		try {
+			setLogicalPath(state, '99.html', 'foo.html');
+			throw new Error('expected throw');
+		} catch (error) {
+			expect(error).toBeInstanceOf(Error);
+			expect(error).not.toBeInstanceOf(PathConflictError);
+			expect((error as Error).message).toContain('99.html');
+		}
+	});
+
+	test('throws PathConflictError when new logical path is taken by another id', () => {
+		const state = makeState([
+			{ id: '1.html', logicalPath: 'about.html' },
+			{ id: '2.html', logicalPath: 'foo/bar.html' },
+		]);
+		expect(() => setLogicalPath(state, '1.html', 'foo/bar.html')).toThrow(
+			PathConflictError,
+		);
+	});
+});
+
+describe('deleteEntry', () => {
+	test('removes the entry', () => {
+		const state = makeState([
+			{ id: '1.html', logicalPath: 'about.html' },
+			{ id: '2.html', logicalPath: 'foo/bar.html' },
+		]);
+		const next = deleteEntry(state, '1.html');
+		expect(toDiskPath(next, 'about.html')).toBeNull();
+		expect(toLogicalPath(next, '1.html')).toBeNull();
+		// remaining entry intact
+		expect(toDiskPath(next, 'foo/bar.html')).toBe('2.html');
+	});
+
+	test('returns the same state reference when the id is unknown (no-op fast path)', () => {
+		const state = makeState([{ id: '1.html', logicalPath: 'about.html' }]);
+		const next = deleteEntry(state, '99.html');
+		expect(next).toBe(state);
+	});
+});
+
+describe('loadResolverState', () => {
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bge-resolver-'));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	/**
+	 *
+	 * @param name
+	 * @param body
+	 */
+	async function writeFile(name: string, body: string) {
+		await fs.writeFile(path.join(tmpDir, name), body, 'utf8');
+	}
+
+	test('builds state from flat <id>.html files with frontmatter path', async () => {
+		await writeFile('1.html', '---\npath: about.html\n---\n<h1>About</h1>\n');
+		await writeFile('2.html', '---\npath: foo/bar.html\n---\n<h1>Bar</h1>\n');
+
+		const state = await loadResolverState(tmpDir, 'path');
+
+		expect(toDiskPath(state, 'about.html')).toBe('1.html');
+		expect(toDiskPath(state, 'foo/bar.html')).toBe('2.html');
+		expect(listLogicalPaths(state).toSorted()).toEqual(['about.html', 'foo/bar.html']);
+	});
+
+	test('honors a custom pathKey', async () => {
+		await writeFile('1.html', '---\nslug: about.html\n---\n<h1>About</h1>\n');
+		const state = await loadResolverState(tmpDir, 'slug');
+		expect(toDiskPath(state, 'about.html')).toBe('1.html');
+	});
+
+	test('throws PathConflictError listing both files that share a logical path', async () => {
+		await writeFile('1.html', '---\npath: about.html\n---\n<h1>One</h1>\n');
+		await writeFile('2.html', '---\npath: about.html\n---\n<h1>Two</h1>\n');
+
+		const error = await loadResolverState(tmpDir, 'path').then(
+			() => null,
+			(error_: unknown) => error_,
+		);
+		expect(error).toBeInstanceOf(PathConflictError);
+		const conflicts = (error as PathConflictError).conflicts;
+		expect(conflicts).toHaveLength(1);
+		expect(conflicts[0]?.logicalPath).toBe('about.html');
+		expect([...(conflicts[0]?.diskFiles ?? [])].toSorted()).toEqual(['1.html', '2.html']);
+	});
+
+	test('throws with a message naming the file when frontmatter pathKey is missing', async () => {
+		await writeFile('1.html', '<h1>No frontmatter</h1>\n');
+
+		await expect(loadResolverState(tmpDir, 'path')).rejects.toThrow(/1\.html/);
+	});
+
+	test('throws when frontmatter has the key but it is not a string (number)', async () => {
+		await writeFile('1.html', '---\npath: 42\n---\n<h1>Bad</h1>\n');
+
+		await expect(loadResolverState(tmpDir, 'path')).rejects.toThrow(/1\.html/);
+	});
+
+	test('ignores non-html files', async () => {
+		await writeFile('1.html', '---\npath: about.html\n---\n<h1>About</h1>\n');
+		await writeFile('readme.md', '# readme');
+		await writeFile('.DS_Store', '');
+
+		const state = await loadResolverState(tmpDir, 'path');
+		expect([...listLogicalPaths(state)]).toEqual(['about.html']);
+	});
+
+	test('does not recurse into subdirectories', async () => {
+		await fs.mkdir(path.join(tmpDir, 'sub'));
+		await fs.writeFile(
+			path.join(tmpDir, 'sub', '99.html'),
+			'---\npath: should/be-ignored.html\n---\n',
+			'utf8',
+		);
+		await writeFile('1.html', '---\npath: about.html\n---\n<h1>About</h1>\n');
+
+		const state = await loadResolverState(tmpDir, 'path');
+		expect([...listLogicalPaths(state)]).toEqual(['about.html']);
+	});
+
+	test('returns an empty state when the directory has no html files', async () => {
+		const state = await loadResolverState(tmpDir, 'path');
+		expect(listLogicalPaths(state)).toEqual([]);
+	});
+
+	test('rejects with ENOENT-style error when documentRoot does not exist', async () => {
+		const missing = path.join(tmpDir, 'missing-dir');
+		await expect(loadResolverState(missing, 'path')).rejects.toThrow();
+	});
+});

--- a/packages/@burger-editor/local/src/model/virtual-path-resolver.ts
+++ b/packages/@burger-editor/local/src/model/virtual-path-resolver.ts
@@ -1,0 +1,283 @@
+/**
+ * Virtual path resolver — bidirectional mapping between disk filenames
+ * (`<id>.html`) and logical paths (`foo/bar/about.html`) for the virtualTree
+ * feature of `@burger-editor/local`.
+ *
+ * ## Error vocabulary
+ *
+ * - {@link IdAlreadyExistsError} — `id` is already mapped to a logical path.
+ *   Thrown by {@link registerEntry} only.
+ * - {@link PathConflictError} — a logical path is claimed by more than one id.
+ *   Thrown by {@link loadResolverState}, {@link registerEntry}, and
+ *   {@link setLogicalPath}.
+ * - Plain `Error` — `id` is unknown. Thrown by {@link setLogicalPath} when the
+ *   caller passes an id that is not currently registered. This is reserved for
+ *   programming errors; route handlers should never see it because they
+ *   resolve the id from `toDiskPath` first.
+ *
+ * ## Constraints on `pathKey` values (= logical paths)
+ *
+ * 1. Must be a non-empty string. {@link loadResolverState} throws on missing /
+ *    non-string values.
+ * 2. Must be unique across the resolver state.
+ * 3. Path-traversal sequences (`..`) are NOT rejected here. Logical paths are
+ *    used purely as map keys and tree-building data; they never reach `fs`.
+ *    See `route.tsx` for the disk-path defense in depth.
+ *
+ * ## State immutability
+ *
+ * All update functions return a new {@link ResolverState} value. The route
+ * layer holds a single mutable reference (`let resolverState = ...`) and
+ * advances it only after the corresponding `saveContent` succeeds (2-phase
+ * commit). Callers that need a true no-op fast path can rely on reference
+ * equality: {@link setLogicalPath} and {@link deleteEntry} return the same
+ * instance when the requested change is a no-op.
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { parseFrontMatter } from '../helpers/front-matter.js';
+
+/**
+ * Bidirectional map between disk filenames and logical paths.
+ *
+ * The two maps are kept in sync; treat the value as immutable and do not
+ * construct it directly outside this module — go through {@link createEmptyState}
+ * + {@link registerEntry} instead.
+ */
+export type ResolverState = {
+	readonly diskToLogical: ReadonlyMap<string, string>;
+	readonly logicalToDisk: ReadonlyMap<string, string>;
+};
+
+/**
+ * Construct an empty resolver state. Use as the seed when building state
+ * incrementally (e.g. tests or migration scripts).
+ */
+export function createEmptyState(): ResolverState {
+	return {
+		diskToLogical: new Map(),
+		logicalToDisk: new Map(),
+	};
+}
+
+export type PathConflict = {
+	readonly logicalPath: string;
+	readonly diskFiles: readonly string[];
+};
+
+export class PathConflictError extends Error {
+	readonly conflicts: readonly PathConflict[];
+
+	constructor(conflicts: readonly PathConflict[]) {
+		const summary = conflicts
+			.map(
+				({ logicalPath, diskFiles }) =>
+					`  - "${logicalPath}" claimed by: ${diskFiles.join(', ')}`,
+			)
+			.join('\n');
+		super(`Conflicting logical paths in virtual tree:\n${summary}`);
+		this.name = 'PathConflictError';
+		this.conflicts = conflicts;
+	}
+}
+
+export class IdAlreadyExistsError extends Error {
+	readonly existingLogicalPath: string;
+	readonly id: string;
+
+	constructor(id: string, existingLogicalPath: string) {
+		super(
+			`File ID "${id}" is already in use (currently mapped to "${existingLogicalPath}").`,
+		);
+		this.name = 'IdAlreadyExistsError';
+		this.id = id;
+		this.existingLogicalPath = existingLogicalPath;
+	}
+}
+
+/**
+ * Resolve the disk filename (`<id>.html`) for a given logical path.
+ * @param state
+ * @param logicalPath logical path from the virtual tree (e.g. `foo/bar/about.html`)
+ * @returns the disk filename, or `null` if the logical path is not registered
+ */
+export function toDiskPath(state: ResolverState, logicalPath: string): string | null {
+	return state.logicalToDisk.get(logicalPath) ?? null;
+}
+
+/**
+ * Resolve the logical path that the given disk filename was registered under.
+ * @param state
+ * @param diskFileName a basename like `<id>.html`
+ * @returns the logical path, or `null` if no such id is registered
+ */
+export function toLogicalPath(state: ResolverState, diskFileName: string): string | null {
+	return state.diskToLogical.get(diskFileName) ?? null;
+}
+
+/**
+ * Snapshot of all logical paths currently registered. Order is the iteration
+ * order of the underlying Map (≈ insertion order); callers that rely on
+ * deterministic order should sort.
+ * @param state
+ */
+export function listLogicalPaths(state: ResolverState): readonly string[] {
+	return [...state.logicalToDisk.keys()];
+}
+
+/**
+ * Register a new (id → logical path) pair and return the next state.
+ * @param state
+ * @param id disk filename, must be unused in `state`
+ * @param logicalPath must be unused in `state`
+ * @returns a new state with the entry added; the original `state` is not mutated
+ * @throws {IdAlreadyExistsError} if `id` is already registered (reports its current logical path)
+ * @throws {PathConflictError} if `logicalPath` is already taken by another id
+ */
+export function registerEntry(
+	state: ResolverState,
+	id: string,
+	logicalPath: string,
+): ResolverState {
+	const existingLogical = state.diskToLogical.get(id);
+	if (existingLogical !== undefined) {
+		throw new IdAlreadyExistsError(id, existingLogical);
+	}
+	if (state.logicalToDisk.has(logicalPath)) {
+		throw new PathConflictError([
+			{
+				logicalPath,
+				diskFiles: [state.logicalToDisk.get(logicalPath)!, id],
+			},
+		]);
+	}
+	const diskToLogical = new Map(state.diskToLogical);
+	const logicalToDisk = new Map(state.logicalToDisk);
+	diskToLogical.set(id, logicalPath);
+	logicalToDisk.set(logicalPath, id);
+	return { diskToLogical, logicalToDisk };
+}
+
+/**
+ * Change the logical path that `id` is mapped to. Use this when the user
+ * edits the Front Matter `pathKey` value of an existing file.
+ *
+ * As an optimization, if `newLogicalPath` equals the current logical path of
+ * `id`, the original `state` reference is returned unchanged so callers can
+ * detect "no work to do" via reference equality (`next === state`).
+ * @param state
+ * @param id disk filename; must already be registered in `state`
+ * @param newLogicalPath the new logical path; must not be taken by another id
+ * @returns a new state with the entry remapped, or the original `state` if no-op
+ * @throws {Error} if `id` is not registered (programming error — callers should resolve via `toDiskPath` first)
+ * @throws {PathConflictError} if `newLogicalPath` is already taken by another id
+ */
+export function setLogicalPath(
+	state: ResolverState,
+	id: string,
+	newLogicalPath: string,
+): ResolverState {
+	const current = state.diskToLogical.get(id);
+	if (current === undefined) {
+		throw new Error(`Unknown disk id: ${id}`);
+	}
+	if (current === newLogicalPath) {
+		// Same path → identity return so callers can detect a no-op via reference equality.
+		return state;
+	}
+	// Past this point `current !== newLogicalPath` and the maps are bidirectionally
+	// consistent, so any occupant of newLogicalPath is by definition another id.
+	const occupant = state.logicalToDisk.get(newLogicalPath);
+	if (occupant !== undefined) {
+		throw new PathConflictError([
+			{ logicalPath: newLogicalPath, diskFiles: [occupant, id] },
+		]);
+	}
+	const diskToLogical = new Map(state.diskToLogical);
+	const logicalToDisk = new Map(state.logicalToDisk);
+	logicalToDisk.delete(current);
+	diskToLogical.set(id, newLogicalPath);
+	logicalToDisk.set(newLogicalPath, id);
+	return { diskToLogical, logicalToDisk };
+}
+
+/**
+ * Remove the entry for `id`. Returns the original `state` reference if `id`
+ * was not registered (no-op fast path), so callers can detect "nothing to do"
+ * via `next === state`.
+ * @param state
+ * @param id disk filename
+ * @returns a new state without the entry, or the original `state` if no-op
+ */
+export function deleteEntry(state: ResolverState, id: string): ResolverState {
+	const current = state.diskToLogical.get(id);
+	if (current === undefined) {
+		return state;
+	}
+	const diskToLogical = new Map(state.diskToLogical);
+	const logicalToDisk = new Map(state.logicalToDisk);
+	diskToLogical.delete(id);
+	logicalToDisk.delete(current);
+	return { diskToLogical, logicalToDisk };
+}
+
+/**
+ * Scan `documentRoot` (non-recursively) for `*.html` files, parse each Front
+ * Matter, and build the bidirectional mapping. Used at server start when
+ * `virtualTree.enabled` is true.
+ * @param documentRoot directory containing the flat `<id>.html` files
+ * @param pathKey Front Matter key to read as the logical path (e.g. `'path'`, `'slug'`)
+ * @returns a fully populated `ResolverState`
+ * @throws {PathConflictError} if any logical path is claimed by more than one file (all conflicts are reported in a single error)
+ * @throws {Error} if a file is missing the `pathKey` or its value is not a non-empty string (the message names the offending file)
+ * @throws {Error} if `documentRoot` does not exist (propagates `fs.readdir` ENOENT)
+ */
+export async function loadResolverState(
+	documentRoot: string,
+	pathKey: string,
+): Promise<ResolverState> {
+	const entries = await fs.readdir(documentRoot, { withFileTypes: true });
+
+	const claims = new Map<string, string[]>();
+	const diskToLogical = new Map<string, string>();
+
+	for (const entry of entries) {
+		if (!entry.isFile() || !entry.name.endsWith('.html')) {
+			continue;
+		}
+		const filePath = path.join(documentRoot, entry.name);
+		const fileContent = await fs.readFile(filePath, 'utf8');
+		const parsed = parseFrontMatter(fileContent);
+
+		const raw = parsed.data[pathKey];
+		if (typeof raw !== 'string' || raw.length === 0) {
+			throw new Error(
+				`Front matter "${pathKey}" missing or not a string in ${entry.name}`,
+			);
+		}
+
+		const logicalPath = raw;
+		diskToLogical.set(entry.name, logicalPath);
+		const list = claims.get(logicalPath) ?? [];
+		list.push(entry.name);
+		claims.set(logicalPath, list);
+	}
+
+	const conflicts: PathConflict[] = [];
+	for (const [logicalPath, diskFiles] of claims) {
+		if (diskFiles.length > 1) {
+			conflicts.push({ logicalPath, diskFiles });
+		}
+	}
+	if (conflicts.length > 0) {
+		throw new PathConflictError(conflicts);
+	}
+
+	const logicalToDisk = new Map<string, string>();
+	for (const [diskFile, logicalPath] of diskToLogical) {
+		logicalToDisk.set(logicalPath, diskFile);
+	}
+
+	return { diskToLogical, logicalToDisk };
+}

--- a/packages/@burger-editor/local/src/route.spec.ts
+++ b/packages/@burger-editor/local/src/route.spec.ts
@@ -1,0 +1,665 @@
+import type { LocalServerConfig } from './types.js';
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { loadResolverState } from './model/virtual-path-resolver.js';
+import { setRoute } from './route.js';
+
+/**
+ * Spin up a fresh tmp documentRoot + assetsRoot pair. Each test gets its own
+ * tree so that file writes don't leak between cases.
+ */
+async function makeTmpDocumentRoot(): Promise<{
+	documentRoot: string;
+	assetsRoot: string;
+}> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), 'bge-route-'));
+	const documentRoot = path.join(root, 'docs');
+	const assetsRoot = path.join(root, 'assets');
+	await fs.mkdir(documentRoot);
+	await fs.mkdir(assetsRoot);
+	return { documentRoot, assetsRoot };
+}
+
+type ConfigOverrides = {
+	virtualTreeEnabled: boolean;
+	pathKey?: string;
+	editableArea?: string | null;
+};
+
+/**
+ *
+ * @param documentRoot
+ * @param assetsRoot
+ * @param overrides
+ */
+function makeConfig(
+	documentRoot: string,
+	assetsRoot: string,
+	overrides: ConfigOverrides,
+): LocalServerConfig {
+	const { virtualTreeEnabled, pathKey = 'path', editableArea = null } = overrides;
+	return {
+		version: '0.0.0-test',
+		port: 0,
+		host: 'localhost',
+		documentRoot,
+		assetsRoot,
+		lang: 'en',
+		stylesheets: [],
+		classList: [],
+		editableArea,
+		indexFileName: 'index.html',
+		filesDir: {
+			image: { serverPath: assetsRoot, clientPath: '/files' },
+			pdf: { serverPath: assetsRoot, clientPath: '/files' },
+			video: { serverPath: assetsRoot, clientPath: '/files' },
+			audio: { serverPath: assetsRoot, clientPath: '/files' },
+			other: { serverPath: assetsRoot, clientPath: '/files' },
+		},
+		sampleImagePath: '/files/sample.png',
+		sampleFilePath: '/files/sample.pdf',
+		googleMapsApiKey: null,
+		open: false,
+		newFileContent: '<!doctype html><html><body></body></html>',
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		catalog: {} as any,
+		enableImportBlock: false,
+		healthCheck: { enabled: false, interval: 10_000, retryCount: 3 },
+		virtualTree: { enabled: virtualTreeEnabled, pathKey },
+	};
+}
+
+/**
+ *
+ * @param documentRoot
+ * @param assetsRoot
+ * @param overrides
+ */
+async function buildApp(
+	documentRoot: string,
+	assetsRoot: string,
+	overrides: ConfigOverrides,
+): Promise<Hono> {
+	const app = new Hono();
+	const userConfig = makeConfig(documentRoot, assetsRoot, overrides);
+	const resolverState = userConfig.virtualTree.enabled
+		? await loadResolverState(userConfig.documentRoot, userConfig.virtualTree.pathKey)
+		: null;
+	setRoute(app, userConfig, resolverState);
+	return app;
+}
+
+describe('GET /api/tree', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('returns logical tree built from frontmatter when virtualTree is enabled', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		await fs.writeFile(
+			path.join(documentRoot, '2.html'),
+			'---\npath: foo/bar.html\n---\n<h1>Bar</h1>\n',
+			'utf8',
+		);
+
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+		const res = await app.request('/api/tree');
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { tree: { name: string; path: string }[] };
+		const names = body.tree.map((n) => n.name).toSorted();
+		expect(names).toEqual(['about.html', 'foo']);
+	});
+
+	test('returns directory-based tree when virtualTree is disabled', async () => {
+		await fs.mkdir(path.join(documentRoot, 'sub'));
+		await fs.writeFile(
+			path.join(documentRoot, 'sub', 'page.html'),
+			'<h1>Page</h1>',
+			'utf8',
+		);
+
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: false });
+		const res = await app.request('/api/tree');
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { tree: { name: string }[] };
+		expect(body.tree.map((n) => n.name)).toEqual(['sub']);
+	});
+});
+
+describe('GET /:page (virtual mode)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('serves an HTML page when the logical path is registered', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: foo/about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/foo/about.html');
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type') ?? '').toMatch(/html/i);
+	});
+
+	test('returns 404 when the logical path is not registered', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: foo/about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/nope/missing.html');
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('POST /api/content/create (virtual mode)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('writes <id>.html with frontmatter and registers logical path', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				id: '42.html',
+				path: 'foo/new.html',
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		const written = await fs.readFile(path.join(documentRoot, '42.html'), 'utf8');
+		expect(written).toContain('path: foo/new.html');
+
+		const treeRes = await app.request('/api/tree');
+		const body = (await treeRes.json()) as { tree: { name: string }[] };
+		expect(body.tree.map((n) => n.name)).toContain('foo');
+	});
+
+	test('appends .html to the id when the caller omits the extension', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ id: '42', path: 'foo.html' }),
+		});
+		expect(res.status).toBe(200);
+		await fs.access(path.join(documentRoot, '42.html'));
+	});
+
+	test('writes the file successfully even when editableArea is set (regression: ENOENT on new files)', async () => {
+		// Production projects almost always set editableArea to a CSS selector, but
+		// saveContent's editableArea path tries to read the existing file first.
+		// /api/content/create must short-circuit that path so new files don't ENOENT.
+		const app = await buildApp(documentRoot, assetsRoot, {
+			virtualTreeEnabled: true,
+			editableArea: 'body',
+		});
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ id: '7.html', path: 'home.html' }),
+		});
+		expect(res.status).toBe(200);
+
+		const written = await fs.readFile(path.join(documentRoot, '7.html'), 'utf8');
+		expect(written).toContain('path: home.html');
+	});
+
+	test('persists supplied content and frontmatter, while pathKey wins over a colliding frontmatter entry', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				id: '5.html',
+				path: 'docs/intro.html',
+				content: '<article>Hello</article>',
+				frontMatter: { title: 'Intro', path: 'wrong.html' },
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		const written = await fs.readFile(path.join(documentRoot, '5.html'), 'utf8');
+		expect(written).toContain('path: docs/intro.html');
+		expect(written).toContain('title: Intro');
+		expect(written).toContain('Hello');
+	});
+
+	test('rejects with 409 when logical path conflicts with an existing entry', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ id: '2.html', path: 'about.html' }),
+		});
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error?: string };
+		expect(body.error).toMatch(/Conflicting logical paths/);
+	});
+
+	test('rejects with 409 and an id-centric message when id already exists on disk', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ id: '1.html', path: 'other.html' }),
+		});
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error?: string };
+		// Must speak about the id collision, not "logical path conflict".
+		expect(body.error).toMatch(/"1\.html" is already in use/);
+		expect(body.error).toContain('about.html');
+		expect(body.error).not.toMatch(/Conflicting logical paths/);
+	});
+
+	test.each([
+		{ label: '../escape', id: '../escape' },
+		{ label: '..\\escape (windows-style)', id: '..\\escape' },
+		{ label: 'subdir/foo', id: 'subdir/foo' },
+		{ label: '..', id: '..' },
+		{ label: '.', id: '.' },
+		{ label: 'leading-dot dotfile', id: '.hidden' },
+		{ label: 'NUL byte', id: 'foo\0bar' },
+	])(
+		'rejects path-traversal id $label without writing outside documentRoot',
+		async ({ id }) => {
+			const app = await buildApp(documentRoot, assetsRoot, {
+				virtualTreeEnabled: true,
+			});
+			const before = await fs.readdir(path.dirname(documentRoot));
+			const res = await app.request('/api/content/create', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ id, path: 'evil.html' }),
+			});
+			expect(res.status).toBeGreaterThanOrEqual(400);
+			expect(res.status).toBeLessThan(500);
+
+			// Nothing was written outside the docRoot.
+			const after = await fs.readdir(path.dirname(documentRoot));
+			expect(after.toSorted()).toEqual(before.toSorted());
+		},
+	);
+
+	test('returns 400 when virtualTree mode is disabled', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: false });
+		const res = await app.request('/api/content/create', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ id: '1.html', path: 'about.html' }),
+		});
+		expect(res.status).toBe(400);
+	});
+});
+
+describe('POST /api/content (virtual mode, path change)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('updates frontmatter path and reflects in tree without moving disk file', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const saveRes = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'about.html',
+				content: '<h1>About</h1>',
+				frontMatter: { path: 'company/about.html' },
+			}),
+		});
+		expect(saveRes.status).toBe(200);
+
+		// disk file at original id stays
+		await fs.access(path.join(documentRoot, '1.html'));
+
+		// tree now exposes the new logical path
+		const treeRes = await app.request('/api/tree');
+		const body = (await treeRes.json()) as { tree: { name: string }[] };
+		expect(body.tree.map((n) => n.name)).toContain('company');
+		expect(body.tree.map((n) => n.name)).not.toContain('about.html');
+	});
+
+	test('keeps state unchanged when frontmatter omits the pathKey', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const saveRes = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'about.html',
+				content: '<h1>About</h1>',
+				frontMatter: { title: 'Renamed Title' },
+			}),
+		});
+		expect(saveRes.status).toBe(200);
+
+		const treeRes = await app.request('/api/tree');
+		const body = (await treeRes.json()) as { tree: { name: string }[] };
+		expect(body.tree.map((n) => n.name)).toEqual(['about.html']);
+	});
+
+	test.each([
+		{ label: 'empty string', value: '' },
+		{ label: 'null', value: null },
+		{ label: 'number', value: 42 },
+		{ label: 'object', value: { nested: 'x' } },
+	])('rejects with 400 when frontmatter pathKey is $label', async ({ value }) => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'about.html',
+				content: '<h1>About</h1>',
+				frontMatter: { path: value },
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	test('rejects with 409 when path change conflicts with another logical path', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		await fs.writeFile(
+			path.join(documentRoot, '2.html'),
+			'---\npath: contact.html\n---\n<h1>Contact</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'about.html',
+				content: '<h1>About</h1>',
+				frontMatter: { path: 'contact.html' },
+			}),
+		});
+		expect(res.status).toBe(409);
+	});
+});
+
+describe('POST /api/content (virtual mode, 2-phase commit)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+		vi.restoreAllMocks();
+	});
+
+	test('does not advance resolverState when saveContent fails', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		// Make the next writeFile call fail (saveContent calls writeFile after Prettier).
+		const writeSpy = vi
+			.spyOn(fs, 'writeFile')
+			.mockRejectedValueOnce(Object.assign(new Error('disk full'), { code: 'ENOSPC' }));
+
+		let saveRes: Response;
+		try {
+			saveRes = await app.request('/api/content', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					path: 'about.html',
+					content: '<h1>About</h1>',
+					frontMatter: { path: 'company/about.html' },
+				}),
+			});
+		} catch (error) {
+			// Hono surfaces unhandled errors as a thrown promise; tolerate either shape.
+			saveRes = new Response(String(error), { status: 500 });
+		}
+
+		expect(saveRes.status).toBeGreaterThanOrEqual(500);
+		writeSpy.mockRestore();
+
+		const treeRes = await app.request('/api/tree');
+		const body = (await treeRes.json()) as { tree: { name: string }[] };
+		// State must not have advanced to the new "company/" path.
+		expect(body.tree.map((n) => n.name)).toEqual(['about.html']);
+	});
+});
+
+describe('POST /api/content (virtual mode, concurrency)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('serializes overlapping path-renames so neither update is lost', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<h1>About</h1>\n',
+			'utf8',
+		);
+		await fs.writeFile(
+			path.join(documentRoot, '2.html'),
+			'---\npath: contact.html\n---\n<h1>Contact</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		// Fire both requests without awaiting, then await as a pair. Without the
+		// state lock, the second write would observe the pre-A state and clobber
+		// A's update.
+		const a = app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'about.html',
+				content: '<h1>About</h1>',
+				frontMatter: { path: 'company/about.html' },
+			}),
+		});
+		const b = app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'contact.html',
+				content: '<h1>Contact</h1>',
+				frontMatter: { path: 'company/contact.html' },
+			}),
+		});
+		const [resA, resB] = await Promise.all([a, b]);
+		expect(resA.status).toBe(200);
+		expect(resB.status).toBe(200);
+
+		const treeRes = await app.request('/api/tree');
+		const body = (await treeRes.json()) as { tree: { name: string }[] };
+		// Both renames must be reflected in the tree.
+		expect(body.tree.map((n) => n.name).toSorted()).toEqual(['company']);
+	});
+});
+
+describe('POST /api/content (non-virtual passthrough)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('rejects ../escape.html in non-virtual mode without writing outside documentRoot', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: false });
+		const before = await fs.readdir(path.dirname(documentRoot));
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: '../escape.html',
+				content: '<h1>Evil</h1>',
+			}),
+		});
+		expect(res.status).toBe(400);
+		const after = await fs.readdir(path.dirname(documentRoot));
+		expect(after.toSorted()).toEqual(before.toSorted());
+	});
+
+	test('writes file at the requested disk path when virtualTree is disabled', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: false });
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'plain.html',
+				content: '<h1>Plain</h1>',
+			}),
+		});
+		expect(res.status).toBe(200);
+		const written = await fs.readFile(path.join(documentRoot, 'plain.html'), 'utf8');
+		expect(written).toContain('<h1>Plain</h1>');
+	});
+
+	test('preserves existing path-rename behavior with editableArea: "body"', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: about.html\n---\n<body><main>old</main></body>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, {
+			virtualTreeEnabled: true,
+			editableArea: 'body',
+		});
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'about.html',
+				content: '<main>new</main>',
+				frontMatter: { path: 'company/about.html' },
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		// Disk file is at the original id; logical tree reflects the new path.
+		const written = await fs.readFile(path.join(documentRoot, '1.html'), 'utf8');
+		expect(written).toContain('new');
+		const treeRes = await app.request('/api/tree');
+		const body = (await treeRes.json()) as { tree: { name: string }[] };
+		expect(body.tree.map((n) => n.name)).toContain('company');
+	});
+});
+
+describe('GET /:page (non-virtual fallthrough)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('serves an existing disk file as HTML when virtualTree is disabled', async () => {
+		await fs.writeFile(path.join(documentRoot, 'home.html'), '<h1>Home</h1>', 'utf8');
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: false });
+
+		const res = await app.request('/home.html');
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type') ?? '').toMatch(/html/i);
+	});
+});

--- a/packages/@burger-editor/local/src/route.tsx
+++ b/packages/@burger-editor/local/src/route.tsx
@@ -14,6 +14,16 @@ import { loadContent, saveContent } from './helpers/edit-content.js';
 import { NoEditableAreaError } from './helpers/no-editable-area-error.js';
 import { defaultConfig } from './model/default-config.js';
 import { FileListManager } from './model/file-list-manager.js';
+import { buildFileTreeFromLogicalPaths, generateFileTree } from './model/file-tree.js';
+import {
+	IdAlreadyExistsError,
+	PathConflictError,
+	listLogicalPaths,
+	registerEntry,
+	setLogicalPath,
+	toDiskPath,
+	type ResolverState,
+} from './model/virtual-path-resolver.js';
 import { App } from './view/app.js';
 
 const clientFileDir = path.resolve(import.meta.dirname, '..', 'dist');
@@ -25,12 +35,58 @@ const apiSchema = z.object({
 	originalFrontMatter: z.string().optional(),
 });
 
+// `id` becomes part of the on-disk filename, so we forbid anything that could
+// break out of documentRoot. The handler additionally re-checks the resolved
+// path as a defense in depth.
+const createApiSchema = z.object({
+	id: z
+		.string()
+		.min(1)
+		.refine(
+			(v) =>
+				!/[/\\]/.test(v) &&
+				v !== '.' &&
+				v !== '..' &&
+				!v.startsWith('.') &&
+				!v.includes('\0'),
+			{
+				message:
+					'id must not contain path separators, NUL bytes, or be "." / ".." / a dotfile',
+			},
+		),
+	path: z.string().min(1),
+	content: z.string().optional(),
+	frontMatter: z.record(z.string(), z.unknown()).optional(),
+});
+
 /**
  *
  * @param app
  * @param userConfig
+ * @param initialResolverState Pre-loaded resolver state (null when virtualTree is disabled)
  */
-export function setRoute(app: Hono, userConfig: LocalServerConfig) {
+export function setRoute(
+	app: Hono,
+	userConfig: LocalServerConfig,
+	initialResolverState: ResolverState | null = null,
+) {
+	const virtualTreeEnabled = userConfig.virtualTree.enabled;
+	const pathKey = userConfig.virtualTree.pathKey;
+	let resolverState: ResolverState | null = initialResolverState;
+
+	// Serialize all resolverState read-modify-write operations to avoid races
+	// where two concurrent saves both observe the same starting state and the
+	// later write clobbers the earlier one.
+	let stateLock: Promise<unknown> = Promise.resolve();
+	/**
+	 *
+	 * @param work
+	 */
+	function withStateLock<T>(work: () => Promise<T>): Promise<T> {
+		const next = stateLock.then(work, work);
+		stateLock = next.catch(() => {});
+		return next;
+	}
 	const fileListManger = {
 		image: new FileListManager(
 			userConfig.filesDir.image.serverPath,
@@ -164,22 +220,137 @@ export function setRoute(app: Hono, userConfig: LocalServerConfig) {
 			if (normalizedPath.endsWith('/')) {
 				normalizedPath += userConfig.indexFileName;
 			}
-			const targetFilePath = path.join(userConfig.documentRoot, normalizedPath);
 
-			await saveContent(
-				targetFilePath,
-				data.content,
-				userConfig.editableArea,
-				data.frontMatter,
-				data.originalFrontMatter,
-			);
+			return withStateLock(async () => {
+				let targetFilePath: string;
+				let nextResolverState: ResolverState | null = resolverState;
+				if (virtualTreeEnabled && resolverState) {
+					const diskFile = toDiskPath(resolverState, normalizedPath);
+					if (!diskFile) {
+						return c.json({ error: `Unknown logical path: ${normalizedPath}` }, 404);
+					}
+					if (data.frontMatter && pathKey in data.frontMatter) {
+						const newLogical = data.frontMatter[pathKey];
+						if (typeof newLogical !== 'string' || newLogical.length === 0) {
+							return c.json(
+								{
+									error: `Front matter "${pathKey}" must be a non-empty string`,
+								},
+								400,
+							);
+						}
+						try {
+							nextResolverState = setLogicalPath(resolverState, diskFile, newLogical);
+						} catch (error) {
+							if (error instanceof PathConflictError) {
+								return c.json({ error: error.message }, 409);
+							}
+							throw error;
+						}
+					}
+					targetFilePath = path.join(userConfig.documentRoot, diskFile);
+				} else {
+					targetFilePath = path.join(userConfig.documentRoot, normalizedPath);
+				}
 
-			log('Saved: %s (with Front Matter: %s)', targetFilePath, !!data.frontMatter);
-			return c.json({
-				saved: true,
-				path: targetFilePath,
-				hasFrontMatter: !!data.frontMatter,
+				// Defense in depth against path traversal via data.path / resolverState.
+				const resolvedRoot = path.resolve(userConfig.documentRoot);
+				const resolvedTarget = path.resolve(targetFilePath);
+				if (
+					resolvedTarget !== resolvedRoot &&
+					!resolvedTarget.startsWith(resolvedRoot + path.sep)
+				) {
+					return c.json(
+						{ error: `Resolved path escapes documentRoot: ${normalizedPath}` },
+						400,
+					);
+				}
+
+				await saveContent(
+					targetFilePath,
+					data.content,
+					userConfig.editableArea,
+					data.frontMatter,
+					data.originalFrontMatter,
+				);
+
+				// 2-phase commit: only advance resolverState after the file write succeeds.
+				resolverState = nextResolverState;
+
+				log('Saved: %s (with Front Matter: %s)', targetFilePath, !!data.frontMatter);
+				return c.json({
+					saved: true,
+					path: targetFilePath,
+					hasFrontMatter: !!data.frontMatter,
+				});
 			});
+		})
+		.post('/api/content/create', zValidator('json', createApiSchema), async (c) => {
+			const data = c.req.valid('json');
+			if (!virtualTreeEnabled) {
+				return c.json(
+					{ error: 'virtualTree mode is disabled; this endpoint is unavailable' },
+					400,
+				);
+			}
+
+			return withStateLock(async () => {
+				if (!resolverState) {
+					return c.json({ error: 'virtualTree resolver state is not initialized' }, 500);
+				}
+				const diskFile = data.id.endsWith('.html') ? data.id : `${data.id}.html`;
+				const targetFilePath = path.join(userConfig.documentRoot, diskFile);
+				// Defense in depth: even if the id schema misses something, refuse
+				// any resolved path that escapes documentRoot.
+				const resolvedRoot = path.resolve(userConfig.documentRoot);
+				const resolvedTarget = path.resolve(targetFilePath);
+				if (
+					resolvedTarget !== resolvedRoot &&
+					!resolvedTarget.startsWith(resolvedRoot + path.sep)
+				) {
+					return c.json(
+						{ error: `Resolved path escapes documentRoot: ${diskFile}` },
+						400,
+					);
+				}
+
+				let nextResolverState: ResolverState;
+				try {
+					nextResolverState = registerEntry(resolverState, diskFile, data.path);
+				} catch (error) {
+					if (
+						error instanceof PathConflictError ||
+						error instanceof IdAlreadyExistsError
+					) {
+						return c.json({ error: error.message }, 409);
+					}
+					throw error;
+				}
+
+				const frontMatter = { ...data.frontMatter, [pathKey]: data.path };
+				const initialContent = data.content ?? userConfig.newFileContent;
+				// New files bypass editableArea: saveContent's editableArea path reads the
+				// existing file first, which would ENOENT for a fresh create.
+				await saveContent(targetFilePath, initialContent, null, frontMatter);
+
+				// 2-phase commit: only advance resolverState after the file write succeeds.
+				resolverState = nextResolverState;
+
+				log('Created: %s -> %s', diskFile, data.path);
+				return c.json({
+					created: true,
+					id: diskFile,
+					path: data.path,
+				});
+			});
+		})
+		.get('/api/tree', async (c) => {
+			if (virtualTreeEnabled && resolverState) {
+				const tree = buildFileTreeFromLogicalPaths(listLogicalPaths(resolverState));
+				return c.json({ tree });
+			}
+			const tree = await generateFileTree(userConfig.documentRoot);
+			return c.json({ tree });
 		})
 		.post(
 			'/api/file/list',
@@ -247,18 +418,28 @@ export function setRoute(app: Hono, userConfig: LocalServerConfig) {
 				<App
 					path={'/'}
 					content={''}
-					rootDir={userConfig.documentRoot}
 					lang={userConfig.lang}
+					virtualTreeEnabled={virtualTreeEnabled}
 				/>,
 			);
 		})
 		.get('/:page{.+\\.html$|.+\\/$}', async (c) => {
 			const page = c.req.param('page');
 
-			let targetFilePath = path.join(userConfig.documentRoot, page);
+			let logicalPath = page;
+			if (logicalPath.endsWith('/')) {
+				logicalPath += userConfig.indexFileName;
+			}
 
-			if (targetFilePath.endsWith('/')) {
-				targetFilePath += userConfig.indexFileName;
+			let targetFilePath: string;
+			if (virtualTreeEnabled && resolverState) {
+				const diskFile = toDiskPath(resolverState, logicalPath);
+				if (!diskFile) {
+					return c.text('Not Found', 404);
+				}
+				targetFilePath = path.join(userConfig.documentRoot, diskFile);
+			} else {
+				targetFilePath = path.join(userConfig.documentRoot, logicalPath);
 			}
 
 			const loadResult = await loadContent(
@@ -272,8 +453,8 @@ export function setRoute(app: Hono, userConfig: LocalServerConfig) {
 					<App
 						path={page}
 						content={loadResult}
-						rootDir={userConfig.documentRoot}
 						lang={userConfig.lang}
+						virtualTreeEnabled={virtualTreeEnabled}
 					/>,
 				);
 			}
@@ -287,8 +468,8 @@ export function setRoute(app: Hono, userConfig: LocalServerConfig) {
 				<App
 					path={page}
 					content={loadResult.editableContent}
-					rootDir={userConfig.documentRoot}
 					lang={userConfig.lang}
+					virtualTreeEnabled={virtualTreeEnabled}
 					frontMatter={loadResult.frontMatter}
 					hasFrontMatter={loadResult.hasFrontMatter}
 				/>,
@@ -349,4 +530,9 @@ async function readFile(filePath: string): Promise<ArrayBuffer | null> {
 	);
 }
 
+/**
+ * Strongly-typed route schema produced by {@link setRoute}. Used by the client
+ * via `hc<AppType>(origin)` so that endpoint paths, request bodies, and
+ * response shapes stay in sync between server and browser.
+ */
 export type AppType = ReturnType<typeof setRoute>;

--- a/packages/@burger-editor/local/src/types.ts
+++ b/packages/@burger-editor/local/src/types.ts
@@ -32,6 +32,24 @@ export interface LocalServerConfig {
 			};
 		};
 	};
+	readonly virtualTree: VirtualTreeConfig;
+}
+
+/**
+ * Configuration for the Virtual File Tree feature. See
+ * `docs/virtual-tree.md` for usage and adoption guidance.
+ */
+export interface VirtualTreeConfig {
+	/**
+	 * Toggle for the feature. When `false` (default) the editor uses the
+	 *  on-disk directory structure as-is.
+	 */
+	readonly enabled: boolean;
+	/**
+	 * Front Matter key whose value is read as the logical path
+	 *  (default: `'path'`).
+	 */
+	readonly pathKey: string;
 }
 
 export type SamplePath = `/${string}` | `https://${string}` | `base64:${string}`;
@@ -40,11 +58,12 @@ export type LocalServerFileDirConfig = Record<FileType, FileDirSettings>;
 
 export type LocalServerConfigUserSettings = Omit<
 	Partial<LocalServerConfig>,
-	'filesDir' | 'healthCheck'
+	'filesDir' | 'healthCheck' | 'virtualTree'
 > & {
 	readonly assetsRoot?: string;
 	readonly filesDir?: string | FileDirSettings | LocalServerFileDirUserSettings;
 	readonly healthCheck?: Partial<LocalServerConfig['healthCheck']>;
+	readonly virtualTree?: Partial<VirtualTreeConfig>;
 };
 
 export type LocalServerFileDirUserSettings = {

--- a/packages/@burger-editor/local/src/view/app.spec.ts
+++ b/packages/@burger-editor/local/src/view/app.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest';
+
+import { NoEditableAreaError } from '../helpers/no-editable-area-error.js';
+
+import { App } from './app.js';
+
+/**
+ *
+ * @param node
+ */
+async function ssr(node: unknown): Promise<string> {
+	return String(await node);
+}
+
+describe('App SSR', () => {
+	test('renders the virtual-tree-enabled flag in the OK content path', async () => {
+		const html = await ssr(
+			App({
+				path: '/x.html',
+				content: '<h1>x</h1>',
+				lang: 'en',
+				virtualTreeEnabled: true,
+			}),
+		);
+		expect(html).toContain('id="virtual-tree-enabled"');
+		expect(html).toContain('value="true"');
+	});
+
+	test('still renders the virtual-tree-enabled flag when content is an Error (regression)', async () => {
+		// Regression: this hidden input used to live inside the non-error branch,
+		// so error pages silently degraded the new-file dialog to non-virtual mode.
+		const html = await ssr(
+			App({
+				path: '/x.html',
+				content: new NoEditableAreaError('body'),
+				lang: 'en',
+				virtualTreeEnabled: true,
+			}),
+		);
+		expect(html).toContain('id="virtual-tree-enabled"');
+		expect(html).toContain('value="true"');
+	});
+
+	test('renders value="false" when virtualTree is disabled', async () => {
+		const html = await ssr(
+			App({
+				path: '/x.html',
+				content: '<h1>x</h1>',
+				lang: 'en',
+				virtualTreeEnabled: false,
+			}),
+		);
+		expect(html).toMatch(/id="virtual-tree-enabled"[^>]*value="false"/);
+	});
+
+	test('skips editor-specific hidden inputs in the Error path', async () => {
+		const html = await ssr(
+			App({
+				path: '/x.html',
+				content: new NoEditableAreaError('body'),
+				lang: 'en',
+				virtualTreeEnabled: false,
+			}),
+		);
+		// editor-only state should be absent on error pages
+		expect(html).not.toContain('id="main"');
+		expect(html).not.toContain('id="front-matter"');
+	});
+
+	test('passes virtualTreeEnabled through to <Nav>', async () => {
+		// If Nav stops respecting the prop, the dialog id input goes missing.
+		const enabled = await ssr(
+			App({
+				path: '/x.html',
+				content: '<h1>x</h1>',
+				lang: 'en',
+				virtualTreeEnabled: true,
+			}),
+		);
+		const disabled = await ssr(
+			App({
+				path: '/x.html',
+				content: '<h1>x</h1>',
+				lang: 'en',
+				virtualTreeEnabled: false,
+			}),
+		);
+		expect(enabled).toContain('name="id"');
+		expect(disabled).not.toContain('name="id"');
+	});
+});

--- a/packages/@burger-editor/local/src/view/app.tsx
+++ b/packages/@burger-editor/local/src/view/app.tsx
@@ -4,8 +4,8 @@ import { Nav } from './nav.js';
 type Props = {
 	path: string;
 	content: string | null | Error;
-	rootDir: string;
 	lang: string;
+	virtualTreeEnabled: boolean;
 	// Front Matter support (optional)
 	frontMatter?: Record<string, unknown>;
 	hasFrontMatter?: boolean;
@@ -16,25 +16,35 @@ type Props = {
  * @param props - Component properties
  * @param props.path - Current page path
  * @param props.content - Page content or error
- * @param props.rootDir - Root directory path
  * @param props.lang - Language code
+ * @param props.virtualTreeEnabled - Whether the server is running in virtualTree mode
  * @param props.frontMatter - Front Matter data
  * @param props.hasFrontMatter - Whether Front Matter exists
  */
 export function App({
 	path,
 	content,
-	rootDir,
 	lang,
+	virtualTreeEnabled,
 	frontMatter,
 	hasFrontMatter,
 }: Props) {
 	return (
 		<Layout lang={lang}>
 			<div class="app">
-				<Nav rootPath={rootDir} />
+				<Nav virtualTreeEnabled={virtualTreeEnabled} />
 				<div class="content">
 					<h1>{path}</h1>
+
+					{/*
+					 * Always render the virtualTree mode flag — `new-file.ts` must read
+					 * it even on error pages where the editor itself isn't mounted.
+					 */}
+					<input
+						type="hidden"
+						id="virtual-tree-enabled"
+						value={String(virtualTreeEnabled)}
+					/>
 
 					{content instanceof Error ? (
 						<p>{content.message}</p>

--- a/packages/@burger-editor/local/src/view/nav.spec.ts
+++ b/packages/@burger-editor/local/src/view/nav.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+
+import { Nav } from './nav.js';
+
+/**
+ * SSR strings used by hono/jsx are async (Promise<string>) when nested. The
+ * Nav component itself is synchronous, but to be future-proof we resolve via
+ * `String(await result)` consistently.
+ * @param node
+ */
+async function ssr(node: unknown): Promise<string> {
+	return String(await node);
+}
+
+describe('Nav SSR', () => {
+	test('renders a path input always, with required attribute', async () => {
+		const html = await ssr(Nav({ virtualTreeEnabled: false }));
+		expect(html).toContain('name="path"');
+		expect(html).toMatch(/name="path"[^>]*required/);
+	});
+
+	test('renders the id input when virtualTreeEnabled is true', async () => {
+		const html = await ssr(Nav({ virtualTreeEnabled: true }));
+		expect(html).toContain('name="id"');
+	});
+
+	test('omits the id input when virtualTreeEnabled is false', async () => {
+		const html = await ssr(Nav({ virtualTreeEnabled: false }));
+		expect(html).not.toContain('name="id"');
+	});
+
+	test('always provides a #nav-tree-mount placeholder for client hydration', async () => {
+		const html = await ssr(Nav({ virtualTreeEnabled: false }));
+		expect(html).toContain('id="nav-tree-mount"');
+	});
+});

--- a/packages/@burger-editor/local/src/view/nav.tsx
+++ b/packages/@burger-editor/local/src/view/nav.tsx
@@ -1,14 +1,16 @@
-import { generateFileTree } from '../model/file-tree.js';
-
-import { NavTree } from './nav-tree.js';
+type Props = {
+	virtualTreeEnabled: boolean;
+};
 
 /**
- *
- * @param root0
- * @param root0.rootPath
+ * Renders the nav skeleton. The file tree is hydrated client-side via GET /api/tree
+ * so this view layer stays agnostic to virtualTree mode for tree data, but it does
+ * expand the new-file dialog to require an `id` field when the server is configured
+ * to use virtual paths.
+ * @param props
+ * @param props.virtualTreeEnabled
  */
-export async function Nav({ rootPath }: { rootPath: string }) {
-	const tree = await generateFileTree(rootPath);
+export function Nav({ virtualTreeEnabled }: Props) {
 	return (
 		<nav class="nav">
 			<div>
@@ -19,8 +21,16 @@ export async function Nav({ rootPath }: { rootPath: string }) {
 			<dialog id="new-file-dialog">
 				<div>
 					<form id="new-file-form" method="dialog">
-						<label>File path</label>
-						<input type="text" name="path" />
+						<label>
+							<span>File path</span>
+							<input type="text" name="path" required />
+						</label>
+						{virtualTreeEnabled ? (
+							<label>
+								<span>File ID</span>
+								<input type="text" name="id" required />
+							</label>
+						) : null}
 					</form>
 				</div>
 				<footer>
@@ -32,9 +42,7 @@ export async function Nav({ rootPath }: { rootPath: string }) {
 					</button>
 				</footer>
 			</dialog>
-			<div>
-				<NavTree items={tree} />
-			</div>
+			<div id="nav-tree-mount"></div>
 		</nav>
 	);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -118,6 +118,7 @@ export default defineConfig({
 					include: [
 						'packages/@burger-editor/local/**/*.spec.ts',
 						'!packages/@burger-editor/local/src/import/**/*.spec.ts',
+						'!packages/@burger-editor/local/src/client/**/*.spec.ts',
 					],
 				},
 			},
@@ -126,6 +127,14 @@ export default defineConfig({
 				test: {
 					name: 'local/import',
 					include: ['packages/@burger-editor/local/src/import/**/*.spec.ts'],
+					...jsdomConfig,
+				},
+			},
+			{
+				extends: './packages/@burger-editor/local/vite.config.ts',
+				test: {
+					name: 'local/client',
+					include: ['packages/@burger-editor/local/src/client/**/*.spec.ts'],
 					...jsdomConfig,
 				},
 			},


### PR DESCRIPTION
## Summary

`@burger-editor/local` に **Virtual File Tree** をオプトインで追加。`virtualTree.enabled = false`（既定）では従来挙動と完全に同じ。`true` にすると、`documentRoot` をフラットな `<id>.html` のまま運用しつつ、各ファイルの Front Matter `path` から論理ツリーを構築してエディタに表示する。外部 CMS / ヘッドレス連携でファイル名がアップストリーム由来の不透明 ID になるユースケース向け。

- サーバ: `model/virtual-path-resolver.ts`（純関数 + `ResolverState` 値型 + `PathConflictError` / `IdAlreadyExistsError`）、`route.tsx` に新規 `GET /api/tree` / `POST /api/content/create`、`POST /api/content` の path 変更対応。`withStateLock` mutex + 2-phase commit + パストラバーサル 2 段防御
- view / client: `view/app` + `view/nav` が `virtualTreeEnabled` prop を受け取り SSR で hidden input + 入力欄を出し分け。`client/nav-tree` が `/api/tree` をハイドレート、`client/new-file` が仮想モード時に ID 入力を要求
- テスト: 138 spec（resolver / file-tree / route / SSR view / client DOM）。並行 race・rollback・traversal の各回帰テストを含む
- ドキュメント: `local/README.md` にセクション追加、`local/docs/virtual-tree.md`（採用ガイド）新規、`ARCHITECTURE.md` に設計判断、新規 export 全てに JSDoc。README の既定値（port / lang / version）の実装乖離も併せて訂正

## Test plan

- [x] `yarn lint` 全パス（eslint / stylelint / markuplint / prettier / textlint / cspell）
- [x] `yarn build` 全パッケージ成功
- [x] `yarn test` 780 passed / 1 skipped（全 13 vitest プロジェクト）
- [x] 仮想モード回帰: resolver pure function 24 件、file-tree builder 6 件、route 結合 31 件、SSR view 9 件、client DOM 10 件
- [x] パストラバーサル攻撃 7 + 1 件を実機で再現確認 → 修正後すべて 400 でブロックされ documentRoot 外への書き込みなし
- [x] 並行 POST race を mutex 無効化で再現確認 → 失敗、mutex 有効化で成功
- [x] Error 経路の hidden input 漏れを SSR で再現確認 → 修正後 OK

## Out of scope (follow-ups filed)

- #753 `client/create-editor.ts` の `res.ok` 分岐に対するテスト整備
- #754 起動時 `loadResolverState` 失敗の終了挙動テスト
- #755 仮想ツリー論理パスの `..` サニタイズ（UX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)