### PR TITLE
fix(deps): downgrade yarn.lock metadata version to 8 for CI compatibility

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 8
   cacheKey: 10c0
 
 "@acemir/cssom@npm:^0.9.31":


### PR DESCRIPTION
## Summary

PR #761 マージ後の dev で CI が失敗していたのを修正する。

`yarn.lock` の \`__metadata.version\` が \`9\`（Yarn 5.x で書かれた形式）になっていたため、CI 上の Yarn 4.12.0 が \`--immutable\` フラグ下で「lockfile を \`version: 8\` に書き換える必要がある」と判定し、テスト本体に到達せず YN0028 で中断していた。

## CI 失敗ログ（[run #27805411979](https://github.com/d-zero-dev/BurgerEditor/actions/runs/27805411979/job/82284105346)）

\`\`\`
➤ YN0028: -  version: 9
➤ YN0028: +  version: 8
➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
\`\`\`

## 対応

volta で固定された Yarn 4.12.0（リポジトリ標準）で \`yarn install\` を実行し、lockfile を再生成。差分は version 表記の 1 行のみ。

\`\`\`diff
 __metadata:
-  version: 9
+  version: 8
   cacheKey: 10c0
\`\`\`

## なぜ version 9 になっていたか

履歴上、誰かが Yarn 5.x（pre-release / 別環境）で \`yarn install\` を走らせて lockfile をコミットしたためと推測される。volta の固定は \`4.12.0\` なので、本来そのバージョンを通せば version: 8 に揃う。

## Test plan

- [x] \`yarn lint\` パス
- [x] \`yarn build\` パス
- [x] \`yarn test\`（Docker VR フル）パス
- [ ] CI が緑になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)