### PR TITLE
fix(inspector,cli): repair test failures introduced by 1c34943

### DIFF
--- a/packages/@burger-editor/cli/src/handlers.spec.ts
+++ b/packages/@burger-editor/cli/src/handlers.spec.ts
@@ -267,27 +267,37 @@ describe('page handlers', () => {
 		).resolves.toBeUndefined();
 	});
 
-	test('pageRename cleans up freshly-created target directories when rename fails', async () => {
-		// chmod 0o555 makes the parent dir read+execute-only — mkdir succeeds
-		// (we create children of THAT parent's children, which is allowed
-		// because mkdir checks ancestor permission), but rename INTO a path
-		// under the readonly tree fails with EACCES. Verifies rollback even
-		// in the EACCES branch (not just EXDEV).
-		const readonlyParent = path.join(docRoot, 'readonly');
-		await fs.mkdir(readonlyParent);
-		await fs.chmod(readonlyParent, 0o555);
-		try {
-			await expect(
-				pageRename(ctx, 'about.html', 'readonly/nested/deeper/new.html'),
-			).rejects.toThrow();
-			// `readonly/nested/deeper` must NOT remain on disk.
-			await expect(fs.access(path.join(readonlyParent, 'nested'))).rejects.toMatchObject({
-				code: 'ENOENT',
-			});
-		} finally {
-			await fs.chmod(readonlyParent, 0o755);
-		}
-	});
+	// chmod 0o555 has no effect for the root user (CI runs as root in some
+	// containers), so the rename would succeed instead of throwing EACCES.
+	// Skip the cleanup-on-EACCES check in that case — the EXDEV branch is
+	// still covered by other rename tests.
+	const isRoot = process.getuid?.() === 0;
+	test.skipIf(isRoot)(
+		'pageRename cleans up freshly-created target directories when rename fails',
+		async () => {
+			// chmod 0o555 makes the parent dir read+execute-only — mkdir succeeds
+			// (we create children of THAT parent's children, which is allowed
+			// because mkdir checks ancestor permission), but rename INTO a path
+			// under the readonly tree fails with EACCES. Verifies rollback even
+			// in the EACCES branch (not just EXDEV).
+			const readonlyParent = path.join(docRoot, 'readonly');
+			await fs.mkdir(readonlyParent);
+			await fs.chmod(readonlyParent, 0o555);
+			try {
+				await expect(
+					pageRename(ctx, 'about.html', 'readonly/nested/deeper/new.html'),
+				).rejects.toThrow();
+				// `readonly/nested/deeper` must NOT remain on disk.
+				await expect(
+					fs.access(path.join(readonlyParent, 'nested')),
+				).rejects.toMatchObject({
+					code: 'ENOENT',
+				});
+			} finally {
+				await fs.chmod(readonlyParent, 0o755);
+			}
+		},
+	);
 
 	test('pageCopy duplicates the file', async () => {
 		await pageCopy(ctx, 'about.html', 'about-copy.html');

--- a/packages/@burger-editor/inspector/src/jsdom-proxy-utils.ts
+++ b/packages/@burger-editor/inspector/src/jsdom-proxy-utils.ts
@@ -17,7 +17,10 @@ function makeStyleIterable(style: CSSStyleDeclaration): Iterable<string> {
 
 /**
  * Create Proxy of jsdom HTMLElement to make el.style iterable
- * jsdom's el.style is not iterable, but browser's is
+ * jsdom's el.style is not iterable, but browser's is. The returned style
+ * object preserves the standard `length` + `item()` + `getPropertyValue()`
+ * interface so consumers that use indexed access (e.g. `exportStyleOptions`)
+ * keep working.
  * @param el HTMLElement from jsdom
  * @returns Proxied HTMLElement where el.style is iterable
  */
@@ -27,8 +30,15 @@ export function proxyJsdomElementForIterableStyle(el: HTMLElement): HTMLElement 
 	return new Proxy(el, {
 		get(target, prop) {
 			if (prop === 'style') {
-				return Object.assign(makeStyleIterable(originalStyle), {
-					getPropertyValue: originalStyle.getPropertyValue.bind(originalStyle),
+				const iterable = makeStyleIterable(originalStyle);
+				return new Proxy(originalStyle, {
+					get(styleTarget, styleProp) {
+						if (styleProp === Symbol.iterator) {
+							return iterable[Symbol.iterator].bind(iterable);
+						}
+						const value = Reflect.get(styleTarget, styleProp);
+						return typeof value === 'function' ? value.bind(styleTarget) : value;
+					},
 				});
 			}
 			return Reflect.get(target, prop);


### PR DESCRIPTION
## Summary

dev で既存だった Test 5 件失敗（[1c34943](https://github.com/d-zero-dev/BurgerEditor/commit/1c34943) で `vitest.config.ts` の default project が `cli` / `file-io` を含むよう広がった以降）を修正する。

PR #762（yarn.lock メタデータ修正）と別建て。両方マージされて初めて dev の CI が緑になる。

## 失敗していたテスト

- `packages/@burger-editor/local/src/commands/search.spec.ts` の 4 件
  - `executes search and finds matches` / `executes AND search with multiple queries` / `executes wildcard search` / `executes OR search`
  - 症状: `result.success` が `false` を返し、マッチ 0 件
- `packages/@burger-editor/cli/src/handlers.spec.ts:282`
  - `pageRename cleans up freshly-created target directories when rename fails`
  - 症状: `rename` が rejected を期待だが resolve（CI が root で動き chmod 0o555 が無視される）

## 修正内容

### `9b7978d` `fix(inspector)`: proxied style に `length` / `item()` を保持

`proxyJsdomElementForIterableStyle` は style に `Symbol.iterator` と `getPropertyValue` だけを露出していた。`@burger-editor/core` の `exportStyleOptions` が indexed access (`length` + `item()`) に切り替わったタイミングで proxy 後の style が機能不全になり、`exportStyleOptions` が `{}` を返すように。結果 `matchesSearchQuery` が常に `false` を返し search 4 件が落ちていた。

`originalStyle` を透過 `Proxy` で包んで `length` / `item()` 等を素通しさせ、`Symbol.iterator` を上乗せ。

### `e58c62a` `test(cli)`: root 実行時に readonly-dir rename テストをスキップ

\`chmod 0o555\` で rename が `EACCES` を投げることを利用するテストだが、root は POSIX 権限チェックをバイパスする。CI コンテナの一部が root で動くため rename が成功してアサーションが落ちていた。

\`test.skipIf(process.getuid?.() === 0)\` でスキップ。EXDEV ロールバック分岐は他の rename テストでカバー、EACCES 分岐は non-root のローカル実行で引き続き検証される。

## なぜ dev に存在していたか

\`1c34943\` の \`vitest.config.ts\` 変更で default project の include が下記に拡張された:

\`\`\`diff
- 'packages/@burger-editor/{frozen-patty,legacy,mcp-server,migrator,utils}/**/*.spec.ts',
+ 'packages/@burger-editor/{cli,file-io,frozen-patty,legacy,mcp-server,migrator,utils}/**/*.spec.ts',
\`\`\`

これと local project の include 拡張により、それまで suite 外で実行されていなかったテスト群が走るようになったが、テスト本体は失敗する状態だった。

## Test plan

- [x] \`yarn lint\` パス
- [x] \`yarn build\` パス
- [x] \`SKIP_DOCKER=1 yarn test\` パス（手元では 599 tests passed、Playwright browser 未インストールで browser project は別途）
- [x] 該当テスト 5 件をローカルで個別確認
  - \`SKIP_DOCKER=1 npx vitest run --project local packages/@burger-editor/local/src/commands/search.spec.ts\` → 17 passed
  - \`SKIP_DOCKER=1 npx vitest run packages/@burger-editor/cli/src/handlers.spec.ts\` → 34 passed（root skip 適用）
- [ ] CI が緑になることを確認
- [ ] PR #762 と本 PR をマージして dev の Test workflow が success に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)