### PR TITLE
fix(core): make block-insertion animation completion reliable

### DIFF
--- a/packages/@burger-editor/core/src/insertion-point.spec.ts
+++ b/packages/@burger-editor/core/src/insertion-point.spec.ts
@@ -115,19 +115,57 @@ describe('InsertionPoint', () => {
 			expect(engine.content.update).toHaveBeenCalled();
 		});
 
-		test('should resolve after transitionend and unwrap insertion element', async () => {
+		test('should resolve after the insertion animation completes and unwrap insertion element', async () => {
+			const engine = createMockEngine();
+			// A short duration keeps this test fast; the point under test is
+			// that a non-zero-duration animation still resolves and unwraps,
+			// not the exact timing.
+			const ip = new InsertionPoint(engine, 10);
+			const insertionBlock = createMockBlock();
+
+			ip.set(null, false);
+			const result = await ip.insert(insertionBlock);
+
+			expect(result).toBe(insertionBlock);
+			expect(engine.isProcessed).toBe(false);
+			expect(engine.save).toHaveBeenCalled();
+		});
+
+		test('should resolve even when the browser reports prefers-reduced-motion (regression)', async () => {
+			// Element.animate()'s `finished` promise settles regardless of the
+			// animation's duration, so a 0ms animation (forced here via
+			// prefers-reduced-motion) must still resolve and clear
+			// engine.isProcessed instead of hanging forever.
+			const matchMediaSpy = vi
+				.spyOn(window, 'matchMedia')
+				.mockReturnValue({ matches: true } as MediaQueryList);
+
 			const engine = createMockEngine();
 			const ip = new InsertionPoint(engine);
 			const insertionBlock = createMockBlock();
 
 			ip.set(null, false);
+			const result = await ip.insert(insertionBlock);
+
+			expect(result).toBe(insertionBlock);
+			expect(engine.isProcessed).toBe(false);
+			expect(engine.save).toHaveBeenCalled();
+
+			matchMediaSpy.mockRestore();
+		});
+
+		test('should still resolve and reset isProcessed if the insertion animation is canceled', async () => {
+			const engine = createMockEngine();
+			// A long duration that we cancel before it would naturally finish,
+			// so the test exercises the `finished` promise's rejection path.
+			const ip = new InsertionPoint(engine, 10_000);
+			const insertionBlock = createMockBlock();
+
+			ip.set(null, false);
 			const promise = ip.insert(insertionBlock);
 
-			// Wait for rAF to set up the transitionend listener
-			await new Promise((resolve) => requestAnimationFrame(resolve));
-
-			// Dispatch transitionend to complete the insertion
-			ip.el.dispatchEvent(new Event('transitionend'));
+			const [animation] = ip.el.getAnimations();
+			animation?.cancel();
 
 			const result = await promise;
 

--- a/packages/@burger-editor/core/src/insertion-point.ts
+++ b/packages/@burger-editor/core/src/insertion-point.ts
@@ -3,7 +3,10 @@ import type { BurgerEditorEngine } from './engine/engine.js';
 
 import { EditorUI } from './editor-ui.js';
 
+const INSERTION_ANIMATION_DURATION_MS = 400;
+
 export class InsertionPoint extends EditorUI {
+	#animationDurationMs: number;
 	#engine: BurgerEditorEngine;
 
 	#insertTarget: {
@@ -11,9 +14,13 @@ export class InsertionPoint extends EditorUI {
 		toTop: boolean;
 	} | null = null;
 
-	constructor(engine: BurgerEditorEngine) {
+	constructor(
+		engine: BurgerEditorEngine,
+		animationDurationMs: number = INSERTION_ANIMATION_DURATION_MS,
+	) {
 		super('insert-point', document.createElement('div'));
 		this.#engine = engine;
+		this.#animationDurationMs = animationDurationMs;
 	}
 
 	insert(insertionBlock: BurgerBlock) {
@@ -38,43 +45,36 @@ export class InsertionPoint extends EditorUI {
 			this.el.append(insertionBlock.el);
 			this.#engine.content.update();
 			this.el.style.height = 'auto';
-			this.el.style.height = `${this.el.getBoundingClientRect().height}px`;
-
-			// 要素を非表示にする
-			this.el.style.display = 'none';
-
-			// アニメーションの準備
+			const targetHeight = this.el.getBoundingClientRect().height;
 			this.el.style.overflow = 'hidden';
-			this.el.style.transition = 'height 0.4s ease';
-			this.el.style.height = '0';
 
-			// 表示してアニメーション開始
-			this.el.style.display = '';
+			// unwrap相当の処理: 親要素の前に要素を挿入し、親要素を削除
+			const finish = () => {
+				const parent = this.el;
+				const child = insertionBlock.el;
 
-			// 次のフレームでアニメーション実行（表示状態に）
-			requestAnimationFrame(() => {
-				this.el.style.height = `${this.el.scrollHeight}px`;
+				if (parent.parentNode) {
+					parent.parentNode.insertBefore(child, parent);
+				}
 
-				// アニメーション完了後の処理
-				this.el.addEventListener(
-					'transitionend',
-					() => {
-						// unwrap相当の処理: 親要素の前に要素を挿入し、親要素を削除
-						const parent = this.el;
-						const child = insertionBlock.el;
+				this.el.remove();
+				this.#engine.save();
+				this.#engine.isProcessed = false;
+				resolve(insertionBlock);
+			};
 
-						if (parent.parentNode) {
-							parent.parentNode.insertBefore(child, parent);
-						}
-
-						this.el.remove();
-						this.#engine.save();
-						this.#engine.isProcessed = false;
-						resolve(insertionBlock);
-					},
-					{ once: true },
-				);
-			});
+			// CSSトランジション + transitionend は、トランジション時間が0の場合
+			// （prefers-reduced-motion 等）にイベントが発火せず isProcessed が
+			// 固着するため使わない。Web Animations API の finished は duration
+			// に関わらず必ず解決するので、それを完了検知に使う
+			const reducedMotion = window.matchMedia?.(
+				'(prefers-reduced-motion: reduce)',
+			).matches;
+			const animation = this.el.animate(
+				[{ height: '0px' }, { height: `${targetHeight}px` }],
+				{ duration: reducedMotion ? 0 : this.#animationDurationMs, easing: 'ease' },
+			);
+			animation.finished.then(finish, finish);
 		});
 	}
 


### PR DESCRIPTION
## 概要

- ブロックを新規追加した直後、そのブロック（および場合によっては既存ブロック全体）がホバーしても編集オーバーレイUIが一切表示されず、移動・削除・コピー等の操作も無反応になる不具合を修正
- 原因: `InsertionPoint.insert()` が挿入アニメーション用の `engine.isProcessed` フラグを CSS `transitionend` イベントでのみ `false` に戻していた。`transitionend` はトランジションの実行時間（duration）が0の場合は発火しない仕様があり、`prefers-reduced-motion: reduce` 等の環境では多くの実装で duration が実質0になるため発火せず、`isProcessed` が `true` のまま固着する。`isProcessed` はホバーオーバーレイ表示・ブロック移動/削除/コピー等の再入防止ガードとして使われているため、一度固着するとエディタ全体が操作不能になる
- Chrome DevTools MCP による実機検証で、ブロック挿入後に既存ブロックを含めページ全体のホバーオーバーレイが機能しなくなることを確認済み

## 変更内容

- `packages/@burger-editor/core/src/insertion-point.ts`: アニメーション完了検知を CSS `transitionend` から `Element.animate()` + `Animation.finished` に置き換え。`finished` は duration に関わらず必ず解決するため、今回の固着は原理的に発生しなくなる。`prefers-reduced-motion: reduce` が有効な場合は明示的に `duration: 0` の分岐を追加（ブラウザの暗黙のduration短縮に依存しない）
- コンストラクタにテスト用の `animationDurationMs` パラメータを追加（本番デフォルトは既存と同じ400ms）
- `insertion-point.spec.ts`: 通常完了・reduced-motion・アニメーションキャンセル（`finished` のreject経路）の3パターンを回帰テストとして追加

## テスト

- `yarn lint` — pass
- `yarn test`（Docker、VR含む） — 80 test files / 934 tests passed, 1 skipped
