### PR TITLE
fix(local): return structured errors and load real content for the site root

### DIFF
--- a/packages/@burger-editor/local/src/route.spec.ts
+++ b/packages/@burger-editor/local/src/route.spec.ts
@@ -811,6 +811,33 @@ describe('POST /api/content (non-virtual passthrough)', () => {
 		expect(written).toContain('<h1>Plain</h1>');
 	});
 
+	test('returns 400 with a JSON error when editableArea selector is not found in the existing file', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, 'no-match.html'),
+			'<body><main>old</main></body>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, {
+			virtualTreeEnabled: false,
+			editableArea: '.missing-class',
+		});
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'no-match.html',
+				content: '<p>new</p>',
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe('Editable area not found: .missing-class');
+
+		const written = await fs.readFile(path.join(documentRoot, 'no-match.html'), 'utf8');
+		expect(written).toBe('<body><main>old</main></body>\n');
+	});
+
 	test('preserves existing path-rename behavior with editableArea: "body"', async () => {
 		await fs.writeFile(
 			path.join(documentRoot, '1.html'),

--- a/packages/@burger-editor/local/src/route.spec.ts
+++ b/packages/@burger-editor/local/src/route.spec.ts
@@ -795,6 +795,25 @@ describe('POST /api/content (non-virtual passthrough)', () => {
 		expect(after.toSorted()).toEqual(before.toSorted());
 	});
 
+	test('returns 404 with a JSON error when the target file does not exist yet', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, {
+			virtualTreeEnabled: false,
+			editableArea: 'body',
+		});
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: 'missing.html',
+				content: '<body>new</body>',
+			}),
+		});
+		expect(res.status).toBe(404);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toBe(`File not found: ${path.join(documentRoot, 'missing.html')}`);
+	});
+
 	test('writes file at the requested disk path when virtualTree is disabled', async () => {
 		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: false });
 
@@ -866,6 +885,73 @@ describe('POST /api/content (non-virtual passthrough)', () => {
 		const treeRes = await app.request('/api/tree');
 		const body = (await treeRes.json()) as { tree: { name: string }[] };
 		expect(body.tree.map((n) => n.name)).toContain('company');
+	});
+});
+
+describe('GET / (site root)', () => {
+	let documentRoot: string;
+	let assetsRoot: string;
+
+	beforeEach(async () => {
+		({ documentRoot, assetsRoot } = await makeTmpDocumentRoot());
+	});
+
+	afterEach(async () => {
+		await fs.rm(path.dirname(documentRoot), { recursive: true, force: true });
+	});
+
+	test('creates and serves index.html on first visit when virtualTree is disabled', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, {
+			virtualTreeEnabled: false,
+			editableArea: 'body',
+		});
+
+		const res = await app.request('/');
+		expect(res.status).toBe(200);
+
+		const written = await fs.readFile(path.join(documentRoot, 'index.html'), 'utf8');
+		expect(written).toBe('<!doctype html><html><body></body></html>');
+	});
+
+	test('allows saving the site root after it has been visited once (regression: FileNotFoundError)', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, {
+			virtualTreeEnabled: false,
+			editableArea: 'body',
+		});
+
+		await app.request('/');
+
+		const res = await app.request('/api/content', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				path: '/',
+				content: '<h1>Home</h1>',
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		const written = await fs.readFile(path.join(documentRoot, 'index.html'), 'utf8');
+		expect(written).toContain('<h1>Home</h1>');
+	});
+
+	test('serves the file mapped to indexFileName when virtualTree is enabled', async () => {
+		await fs.writeFile(
+			path.join(documentRoot, '1.html'),
+			'---\npath: index.html\n---\n<h1>Home</h1>\n',
+			'utf8',
+		);
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/');
+		expect(res.status).toBe(200);
+	});
+
+	test('returns 404 when virtualTree is enabled and no file maps to indexFileName', async () => {
+		const app = await buildApp(documentRoot, assetsRoot, { virtualTreeEnabled: true });
+
+		const res = await app.request('/');
+		expect(res.status).toBe(404);
 	});
 });
 

--- a/packages/@burger-editor/local/src/route.tsx
+++ b/packages/@burger-editor/local/src/route.tsx
@@ -1,6 +1,6 @@
 import type { LocalServerConfig } from './types.js';
 import type { FileListResult } from '@burger-editor/core';
-import type { Hono } from 'hono';
+import type { Context, Hono } from 'hono';
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -10,7 +10,7 @@ import { z } from 'zod';
 
 import { HEALTH_CHECK_END_POINT } from './constants.js';
 import { log } from './helpers/debug.js';
-import { loadContent, saveContent } from './helpers/edit-content.js';
+import { FileNotFoundError, loadContent, saveContent } from './helpers/edit-content.js';
 import { NoEditableAreaError } from './helpers/no-editable-area-error.js';
 import { defaultConfig } from './model/default-config.js';
 import { FileListManager } from './model/file-list-manager.js';
@@ -141,6 +141,60 @@ export function setRoute(
 			userConfig.sampleFilePath,
 		),
 	} as const;
+
+	/**
+	 * Shared by `GET /` and the `GET /:page` wildcard so the site root loads
+	 * (and, if missing, creates) real file content instead of a blank editor
+	 * that can never be saved.
+	 * @param c
+	 * @param page
+	 * @param logicalPath
+	 */
+	async function renderPage(c: Context, page: string, logicalPath: string) {
+		let targetFilePath: string;
+		if (virtualTreeEnabled && resolverState) {
+			const diskFile = toDiskPath(resolverState, logicalPath);
+			if (!diskFile) {
+				return c.text('Not Found', 404);
+			}
+			targetFilePath = path.join(userConfig.documentRoot, diskFile);
+		} else {
+			targetFilePath = path.join(userConfig.documentRoot, logicalPath);
+		}
+
+		const loadResult = await loadContent(
+			targetFilePath,
+			userConfig.editableArea,
+			userConfig.newFileContent,
+		);
+
+		if (loadResult instanceof NoEditableAreaError) {
+			return c.html(
+				<App
+					path={page}
+					content={loadResult}
+					lang={userConfig.lang}
+					virtualTreeEnabled={virtualTreeEnabled}
+				/>,
+			);
+		}
+		log(
+			'Loaded page with Front Matter: %s (keys: %o)',
+			loadResult.hasFrontMatter,
+			Object.keys(loadResult.frontMatter),
+		);
+
+		return c.html(
+			<App
+				path={page}
+				content={loadResult.editableContent}
+				lang={userConfig.lang}
+				virtualTreeEnabled={virtualTreeEnabled}
+				frontMatter={loadResult.frontMatter}
+				hasFrontMatter={loadResult.hasFrontMatter}
+			/>,
+		);
+	}
 
 	const routes = app
 		// ------------------------------------------------------------------------------------------
@@ -316,6 +370,9 @@ export function setRoute(
 					if (error instanceof NoEditableAreaError) {
 						return c.json({ error: error.message }, 400);
 					}
+					if (error instanceof FileNotFoundError) {
+						return c.json({ error: error.message }, 404);
+					}
 					throw error;
 				}
 
@@ -461,15 +518,8 @@ export function setRoute(
 		// Page
 		//
 		// ------------------------------------------------------------------------------------------
-		.get('/', (c) => {
-			return c.html(
-				<App
-					path={'/'}
-					content={''}
-					lang={userConfig.lang}
-					virtualTreeEnabled={virtualTreeEnabled}
-				/>,
-			);
+		.get('/', async (c) => {
+			return renderPage(c, '/', userConfig.indexFileName);
 		})
 		.get('/:page{.+\\.html$|.+\\/$}', async (c) => {
 			const page = c.req.param('page');
@@ -479,49 +529,7 @@ export function setRoute(
 				logicalPath += userConfig.indexFileName;
 			}
 
-			let targetFilePath: string;
-			if (virtualTreeEnabled && resolverState) {
-				const diskFile = toDiskPath(resolverState, logicalPath);
-				if (!diskFile) {
-					return c.text('Not Found', 404);
-				}
-				targetFilePath = path.join(userConfig.documentRoot, diskFile);
-			} else {
-				targetFilePath = path.join(userConfig.documentRoot, logicalPath);
-			}
-
-			const loadResult = await loadContent(
-				targetFilePath,
-				userConfig.editableArea,
-				userConfig.newFileContent,
-			);
-
-			if (loadResult instanceof NoEditableAreaError) {
-				return c.html(
-					<App
-						path={page}
-						content={loadResult}
-						lang={userConfig.lang}
-						virtualTreeEnabled={virtualTreeEnabled}
-					/>,
-				);
-			}
-			log(
-				'Loaded page with Front Matter: %s (keys: %o)',
-				loadResult.hasFrontMatter,
-				Object.keys(loadResult.frontMatter),
-			);
-
-			return c.html(
-				<App
-					path={page}
-					content={loadResult.editableContent}
-					lang={userConfig.lang}
-					virtualTreeEnabled={virtualTreeEnabled}
-					frontMatter={loadResult.frontMatter}
-					hasFrontMatter={loadResult.hasFrontMatter}
-				/>,
-			);
+			return renderPage(c, page, logicalPath);
 		})
 		// ------------------------------------------------------------------------------------------
 		//

--- a/packages/@burger-editor/local/src/route.tsx
+++ b/packages/@burger-editor/local/src/route.tsx
@@ -304,13 +304,20 @@ export function setRoute(
 					);
 				}
 
-				await saveContent(
-					targetFilePath,
-					data.content,
-					userConfig.editableArea,
-					data.frontMatter,
-					data.originalFrontMatter,
-				);
+				try {
+					await saveContent(
+						targetFilePath,
+						data.content,
+						userConfig.editableArea,
+						data.frontMatter,
+						data.originalFrontMatter,
+					);
+				} catch (error) {
+					if (error instanceof NoEditableAreaError) {
+						return c.json({ error: error.message }, 400);
+					}
+					throw error;
+				}
 
 				// 2-phase commit: only advance resolverState after the file write succeeds.
 				resolverState = nextResolverState;


### PR DESCRIPTION
## 概要

ローカルCMSの `POST /api/content`（保存API）で、保存対象のHTMLに関する2種類のドメインエラーが未 catch のまま Hono ハンドラを素通しし、クライアントに `Internal Server Error`（本文なし）としてしか伝わらない不具合を2件まとめて修正:

1. **editableArea セレクタ不一致（`NoEditableAreaError`）**: 保存対象のHTMLに設定済みの `editableArea` セレクタが見つからない場合に発生。読み込み側（`GET`）は既にこの例外を受け取って専用画面を表示していたが、保存側だけ未対応だった
2. **サイトルート（`GET /`）が実コンテンツを読み込んでいない**: `.get('/', ...)` が `loadContent` を呼ばず常に空コンテンツを返す実装になっていたため、ルートを編集して保存すると対応する `index.html` が存在せず `saveContent` が `FileNotFoundError` を投げていた（同じく未 catch で 500 に）

## 変更内容

- `packages/@burger-editor/local/src/route.tsx`
  - `POST /api/content` の `saveContent` 呼び出しを `try/catch` で囲み、`NoEditableAreaError` → 400、`FileNotFoundError` → 404 の構造化JSONエラーに変換（既存の `PathConflictError`/`EmptyLogicalPathError` と同じ規約）
  - `GET /:page` ワイルドカードのページ描画ロジックを `renderPage()` として切り出し、`GET /` からも同じ関数を呼ぶように変更。サイトルートも他ページと同様に `loadContent` 経由で実ファイルを読み込み・自動作成するようになった
- `packages/@burger-editor/local/src/route.spec.ts`: 上記各ケースの回帰テストを追加（editableArea不一致時の400、ファイル未存在時の404、サイトルートの自動作成・保存・virtualTreeモードでの解決/404）

## テスト

- `yarn lint` — pass
- `yarn test`（Docker、VR含む） — 80 test files / 938 tests passed, 1 skipped（`local/commands/server.spec.ts` のQEMU起因タイムアウトは既知の環境フレークで、再実行でグリーンになることを確認済み）
