### PR TITLE
fix(core,client): drive block-menu visibility through React state only

### DIFF
--- a/packages/@burger-editor/client/src/components/block-menu.spec.tsx
+++ b/packages/@burger-editor/client/src/components/block-menu.spec.tsx
@@ -1,0 +1,158 @@
+import type { BurgerBlock } from '@burger-editor/core';
+
+import { getBlockAtPosition } from '@burger-editor/core';
+import { cleanup, render } from '@testing-library/react';
+import { act, createRef } from 'react';
+import { test, expect, afterEach, vi } from 'vitest';
+
+import { BlockMenu, type BlockMenuHandle } from './block-menu.js';
+
+// vi.mock calls are hoisted above these imports by vitest's transform.
+vi.mock('@burger-editor/core', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@burger-editor/core')>();
+	return {
+		...actual,
+		getBlockAtPosition: vi.fn(),
+	};
+});
+
+// jsdom doesn't implement the CSSOM `CSS` global (no CSS.escape), which
+// BlockMenuButton uses to build an anchor name. Minimal polyfill scoped to
+// this test file only; it isn't exercised in production (real browsers).
+if (globalThis.CSS === undefined) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	(globalThis as any).CSS = {
+		escape: (value: string) => String(value).replaceAll(/[^\w-]/g, (ch) => `\\${ch}`),
+	};
+}
+
+afterEach(() => {
+	cleanup();
+	vi.clearAllMocks();
+});
+
+/**
+ * jsdom does not compute `pageX`/`pageY` from `clientX`/`clientY`, so set
+ * them directly to make the coordinates the component reads deterministic.
+ * @param target
+ * @param pageX
+ * @param pageY
+ */
+function dispatchMouseMove(target: EventTarget, pageX: number, pageY: number) {
+	const event = new MouseEvent('mousemove', { bubbles: true });
+	Object.defineProperty(event, 'pageX', { value: pageX });
+	Object.defineProperty(event, 'pageY', { value: pageY });
+	target.dispatchEvent(event);
+}
+
+/**
+ *
+ */
+function createMockEngine() {
+	const el = document.createElement('div');
+	return {
+		el,
+		isProcessed: false,
+		componentObserver: { notify: vi.fn() },
+		uiState: { openItemEditor: vi.fn() },
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any;
+}
+
+/**
+ *
+ */
+function createMockBlock(): BurgerBlock {
+	const el = document.createElement('div');
+	const block = {
+		el,
+		isMutable: () => false,
+		is: (other: unknown) => other === block,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any;
+	return block;
+}
+
+test('ref.hide() forces the menu hidden even when React state already marked it visible', async () => {
+	const engine = createMockEngine();
+	const container = document.createElement('div');
+	document.body.append(container);
+	const ref = createRef<BlockMenuHandle>();
+	const block = createMockBlock();
+
+	vi.mocked(getBlockAtPosition).mockReturnValue({
+		block,
+		rect: {
+			left: 0,
+			top: 0,
+			right: 100,
+			bottom: 100,
+			width: 100,
+			height: 100,
+		} as DOMRect,
+		marginBlockEnd: 0,
+	});
+
+	const { container: renderedRoot } = render(
+		<BlockMenu ref={ref} engine={engine} container={container} onHide={vi.fn()} />,
+	);
+	const menuEl = renderedRoot.firstElementChild as HTMLElement;
+
+	// A real hover makes the menu visible via React state (not a raw DOM write).
+	await act(async () => {
+		dispatchMouseMove(document.body, 10, 10);
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+	});
+	expect(menuEl.hidden).toBe(false);
+
+	// The regression: previously, an external caller forced `hidden = true`
+	// directly on the DOM without updating React's `visible` state. A later
+	// hover calling `setVisible(true)` with the value React already believed
+	// to be true was then skipped as a no-op, leaving the menu stuck hidden.
+	act(() => {
+		ref.current?.hide();
+	});
+	expect(menuEl.hidden).toBe(true);
+
+	// A subsequent hover must still be able to show the menu again — proving
+	// ref.hide() reset React's own state rather than only the DOM attribute.
+	await act(async () => {
+		dispatchMouseMove(document.body, 10, 10);
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+	});
+	expect(menuEl.hidden).toBe(false);
+});
+
+test('ref.hide() clears the currently selected block', async () => {
+	const engine = createMockEngine();
+	const container = document.createElement('div');
+	document.body.append(container);
+	const ref = createRef<BlockMenuHandle>();
+	const onHide = vi.fn();
+	const block = createMockBlock();
+
+	vi.mocked(getBlockAtPosition).mockReturnValue({
+		block,
+		rect: {
+			left: 0,
+			top: 0,
+			right: 100,
+			bottom: 100,
+			width: 100,
+			height: 100,
+		} as DOMRect,
+		marginBlockEnd: 0,
+	});
+
+	render(<BlockMenu ref={ref} engine={engine} container={container} onHide={onHide} />);
+
+	await act(async () => {
+		dispatchMouseMove(document.body, 10, 10);
+		await new Promise((resolve) => requestAnimationFrame(resolve));
+	});
+
+	act(() => {
+		ref.current?.hide();
+	});
+	expect(onHide).toHaveBeenCalledTimes(1);
+});

--- a/packages/@burger-editor/client/src/components/block-menu.tsx
+++ b/packages/@burger-editor/client/src/components/block-menu.tsx
@@ -18,7 +18,15 @@ import {
 	IconSettings,
 	IconTrash,
 } from '@tabler/icons-react';
-import { useId, useEffect, useRef, useState } from 'react';
+import {
+	useId,
+	useEffect,
+	useRef,
+	useState,
+	useCallback,
+	useImperativeHandle,
+	forwardRef,
+} from 'react';
 
 import { useCommand } from '../use-command.js';
 
@@ -42,34 +50,56 @@ interface ItemOverlayRect {
 }
 
 /**
+ * Imperative handle exposed via ref so callers (e.g. `engine.isProcessed`'s
+ * setter) can force the menu hidden through React state instead of poking
+ * the DOM directly. A direct DOM write leaves React's own `visible` state
+ * unaware of the change, so a later `setVisible(true)` with the same value
+ * it already held gets skipped as a no-op re-render — the menu then stays
+ * stuck hidden even though the user is hovering a block.
+ * @example
+ * ```ts
+ * const menuRef = createRef<BlockMenuHandle>();
+ * // ... mount <BlockMenu ref={menuRef} .../> ...
+ * menuRef.current?.hide();
+ * ```
+ */
+export interface BlockMenuHandle {
+	readonly hide: () => void;
+}
+
+/**
  * Hover menu over the selected block inside the editable area iframe.
  * Block operations are declared as engine commands; positioning and
- * visibility stay local to this component.
+ * visibility stay local to this component. Exposes {@link BlockMenuHandle}
+ * via ref so external code can hide it without racing React's own state.
  * @param root0
  * @param root0.engine
  * @param root0.container
  * @param root0.onHide
+ * @param ref - Imperative handle; see {@link BlockMenuHandle}
  * @example
  * ```tsx
+ * const menuRef = createRef<BlockMenuHandle>();
  * reactMount(
  * 	<BlockMenu
+ * 		ref={menuRef}
  * 		engine={engine}
  * 		container={container}
  * 		onHide={() => engine.clearCurrentBlock()}
  * 	/>,
  * 	container,
  * );
+ * menuRef.current?.hide();
  * ```
  */
-export function BlockMenu({
-	engine,
-	container,
-	onHide,
-}: {
-	readonly engine: BurgerEditorEngine;
-	readonly container: HTMLElement;
-	readonly onHide: () => void;
-}) {
+export const BlockMenu = forwardRef<
+	BlockMenuHandle,
+	{
+		readonly engine: BurgerEditorEngine;
+		readonly container: HTMLElement;
+		readonly onHide: () => void;
+	}
+>(function BlockMenu({ engine, container, onHide }, ref) {
 	const menuId = useId();
 	const [currentBlock, setCurrentBlock] = useState<BurgerBlock | null>(null);
 	const [visible, setVisible] = useState(false);
@@ -100,6 +130,14 @@ export function BlockMenu({
 		},
 	});
 
+	const hide = useCallback(() => {
+		setVisible(false);
+		setCurrentBlock(null);
+		onHide();
+	}, [onHide]);
+
+	useImperativeHandle(ref, () => ({ hide }), [hide]);
+
 	useEffect(() => {
 		const onBlockChange = (e: CustomEvent<{ readonly block: BurgerBlock }>) => {
 			setCurrentBlock(e.detail.block);
@@ -118,12 +156,6 @@ export function BlockMenu({
 		let mouseX = 0;
 		let mouseY = 0;
 		let raf = 0;
-
-		const hide = () => {
-			setVisible(false);
-			setCurrentBlock(null);
-			onHide();
-		};
 
 		const updatePosition = () => {
 			const selected = getBlockAtPosition(doc, mouseX, mouseY);
@@ -234,7 +266,7 @@ export function BlockMenu({
 			observer.disconnect();
 			cancelAnimationFrame(raf);
 		};
-	}, [engine, container, onHide]);
+	}, [engine, container, hide]);
 
 	const isMutable = currentBlock?.isMutable();
 
@@ -346,4 +378,4 @@ export function BlockMenu({
 			</div>
 		</div>
 	);
-}
+});

--- a/packages/@burger-editor/client/src/index.tsx
+++ b/packages/@burger-editor/client/src/index.tsx
@@ -1,7 +1,9 @@
+import type { BlockMenuHandle } from './components/block-menu.js';
 import type { BurgerEditorEngineOptions } from '@burger-editor/core';
 
 import { BurgerEditorEngine } from '@burger-editor/core';
 import { defineBgeWysiwygEditorElement } from '@burger-editor/custom-element';
+import { createRef } from 'react';
 
 import { BurgerEditorRoot } from './burger-editor-root.js';
 import { registerEngineCommands } from './commands/register-engine-commands.js';
@@ -73,8 +75,10 @@ export async function createBurgerEditorClient(
 			return reactMount(<InitialInsertionButton />, container);
 		},
 		blockMenu: (container, engine) => {
+			const menuRef = createRef<BlockMenuHandle>();
 			const { cleanUp } = reactMount(
 				<BlockMenu
+					ref={menuRef}
 					engine={engine}
 					container={container}
 					onHide={() => engine.clearCurrentBlock()}
@@ -83,7 +87,21 @@ export async function createBurgerEditorClient(
 			);
 
 			return {
-				hide: () => engine.clearCurrentBlock(),
+				// ref経由でReactのvisible状態を更新する。DOMのhidden属性を直接
+				// 書き換えるとReactの内部状態と食い違い、以後の同値setState
+				// （例: 再ホバーでの setVisible(true)）がReactの再描画をスキップ
+				// し続けて永久に隠れたままになる。engine.clearCurrentBlock() は
+				// BlockMenu の onHide 経由で呼ばれるため、ここでは呼ばない
+				hide: () => {
+					if (!menuRef.current) {
+						// eslint-disable-next-line no-console
+						console.warn(
+							'blockMenu.hide() called before the BlockMenu ref was attached; the menu could not be hidden.',
+						);
+						return;
+					}
+					menuRef.current.hide();
+				},
 				cleanUp,
 			};
 		},

--- a/packages/@burger-editor/core/src/editable-area.spec.ts
+++ b/packages/@burger-editor/core/src/editable-area.spec.ts
@@ -41,7 +41,7 @@ function createMockEngine() {
  *
  */
 function createMockBlockMenuCreator() {
-	return vi.fn().mockReturnValue({ cleanUp: vi.fn() });
+	return vi.fn().mockReturnValue({ cleanUp: vi.fn(), hide: vi.fn() });
 }
 
 describe('EditableArea', () => {
@@ -107,6 +107,19 @@ describe('EditableArea', () => {
 			const ea = new EditableArea('main', '', engine, createMockBlockMenuCreator());
 
 			expect(ea.blockMenu).toBeDefined();
+		});
+
+		test("blockMenu.hide() delegates to the creator's hide without touching the DOM directly", () => {
+			const engine = createMockEngine();
+			const blockMenuCreator = createMockBlockMenuCreator();
+			const ea = new EditableArea('main', '', engine, blockMenuCreator);
+			const { hide: createdHide } = blockMenuCreator.mock.results[0]?.value as {
+				hide: ReturnType<typeof vi.fn>;
+			};
+
+			ea.blockMenu.hide();
+
+			expect(createdHide).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/packages/@burger-editor/core/src/editable-area.ts
+++ b/packages/@burger-editor/core/src/editable-area.ts
@@ -112,10 +112,11 @@ export class EditableArea<T extends EditableAreaType = 'main'> extends EditorUI 
 		const { hide: blockMenuHide } = createBlockMenu(blockMenuEl, engine);
 		this.blockMenu = {
 			el: blockMenuEl,
-			hide: () => {
-				blockMenuEl.hidden = true;
-				blockMenuHide();
-			},
+			// blockMenuHide はReactのvisible状態を経由してhidden属性を更新する
+			// （DOMを直接書き換えない）。真実の源をReactの状態1つに保つことで、
+			// 外部からの強制非表示とホバー時の再表示が食い違って永久に隠れた
+			// ままになる不整合を構造的に防ぐ
+			hide: blockMenuHide,
 		};
 
 		this.insertionPoint = new InsertionPoint(this.#engine);

--- a/packages/@burger-editor/core/src/engine/engine.ts
+++ b/packages/@burger-editor/core/src/engine/engine.ts
@@ -66,7 +66,9 @@ export class BurgerEditorEngine {
 	}
 
 	set isProcessed(isProcessed: boolean) {
-		this.content.blockMenu.hide();
+		if (isProcessed) {
+			this.content.blockMenu.hide();
+		}
 		this.#isProcessed = isProcessed;
 	}
 


### PR DESCRIPTION
## 概要

PR #834（`fix/insertion-point-animation-lockup`）とPR #835（`fix/local`系）をマージ後、ユーザーが実機検証したところ「ブロック追加直後にホバーで編集オーバーレイが出ない」症状が**まだ再現する**ことが判明。調査の結果、PR #834とは独立した別バグが根本原因だった。

## 原因

`packages/@burger-editor/core/src/engine/engine.ts` の `isProcessed` セッターが、`true`/`false` どちらにセットしても無条件で `blockMenu.hide()` を呼んでいた。本番の `hide` 実装（`client/index.tsx` → `core/editable-area.ts` 経由）は Reactの状態管理を経由せず `blockMenuEl.hidden = true` を **DOMへ直接書き込んで**いた。

`BlockMenu`（Reactコンポーネント）は自前の `useState`（`visible`）で `hidden={!visible}` を描画しているため、外部からDOM属性を直接書き換えられてもReact自身が保持する `visible` の値は変わらない。その後ホバーで `setVisible(true)` が呼ばれても、Reactから見て値に変化がなければ（前回のホバーで既に `visible === true` だった場合など）Reactは再描画をスキップし、`hidden` 属性が `true` に固着したまま二度と戻らなくなっていた。

Chrome DevTools MCPで実機を操作し、`hidden` 属性への書き込みにスタックトレース付きフックを仕掛けて、`set isProcessed` からの直接DOM書き込みが原因であることを実機で確定させた。

## 修正内容

DOM直接操作を完全に廃止し、**Reactの状態管理に一本化**（真実の源を1つにすることで、このクラスのバグの再発を構造的に防ぐ）。

- `packages/@burger-editor/client/src/components/block-menu.tsx`: `BlockMenu` を `forwardRef` + `useImperativeHandle` 化し、`{ hide }` を公開。`hide` はコンポーネント自身の `setVisible(false)` を呼ぶ
- `packages/@burger-editor/client/src/index.tsx`: `blockMenu` ファクトリがrefを保持し、`hide` はref経由で呼ぶよう変更（DOM直接操作を削除）
- `packages/@burger-editor/core/src/editable-area.ts`: `blockMenuEl.hidden = true` の直接書き込みを削除
- `packages/@burger-editor/core/src/engine/engine.ts`: `isProcessed` セッターを `true` になる時だけ `hide()` を呼ぶようガード

## テスト

- `packages/@burger-editor/client/src/components/block-menu.spec.tsx`（新規）: `ref.hide()` がReact状態を正しく更新し、その後のホバーで再表示できることを検証する回帰テスト
- `packages/@burger-editor/core/src/editable-area.spec.ts`: `blockMenu.hide()` が生成された `hide` に委譲することを検証するテストを追加
- **実機検証（Chrome DevTools MCP）**: 隔離したscratch環境で本番ビルドを実際に起動し、ブロックを複数回挿入 → 直後にホバー → 編集オーバーレイが正しく表示されることを確認。既存の他ブロックのホバーも継続して動作することを確認（グローバルな固着の再発なし）
- `yarn lint` — pass
- `yarn test`（Docker、VR含む） — 81 test files / 943 tests passed, 1 skipped
