### PR TITLE
fix(core): stop passing containerElement itself to BurgerBlock.rebind

### DIFF
--- a/packages/@burger-editor/core/src/block/block.ts
+++ b/packages/@burger-editor/core/src/block/block.ts
@@ -142,18 +142,6 @@ export class BurgerBlock {
 		return parseHTMLToBlockData(this.el);
 	}
 
-	#fallbackBlockData(html: string): BlockData {
-		return {
-			name: 'text',
-			containerProps: {
-				type: 'grid',
-				columns: 1,
-			},
-			classList: [],
-			items: [[{ name: 'wysiwyg', data: { wysiwyg: html } }]],
-		};
-	}
-
 	async #import(data: BlockData) {
 		this.el.replaceWith(
 			await createPlainStructuredBlockElement(data, this.#createItemElement),
@@ -175,7 +163,7 @@ export class BurgerBlock {
 		// eslint-disable-next-line no-console
 		console.error('%o is not a burger block', el);
 		const fallbackEl = await createPlainStructuredBlockElement(
-			this.#fallbackBlockData(el.outerHTML),
+			fallbackBlockData(el.outerHTML),
 			this.#createItemElement,
 		);
 		el.replaceWith(fallbackEl);
@@ -196,6 +184,23 @@ export class BurgerBlock {
 		return block;
 	}
 
+	/**
+	 * Build a block from raw HTML that carries no burger-block markers,
+	 * wrapping it as a single `wysiwyg` item instead of trying to parse
+	 * a block structure out of it.
+	 * @param html - Raw HTML to preserve as-is inside the fallback block
+	 * @param createItemElement - Factory used to materialize the wysiwyg item element
+	 * @returns The constructed fallback {@link BurgerBlock}
+	 * @example
+	 * ```ts
+	 * const block = await BurgerBlock.createFallback('<p>hello</p>', createItemElement);
+	 * container.append(block.el);
+	 * ```
+	 */
+	static createFallback(html: string, createItemElement: CreateItemElement) {
+		return BurgerBlock.create(fallbackBlockData(html), createItemElement);
+	}
+
 	static async rebind(el: HTMLElement, createItemElement: CreateItemElement) {
 		const block = new BurgerBlock(createItemElement);
 		const newEl = await block.#rebind(el);
@@ -210,6 +215,22 @@ export class BurgerBlock {
 		}
 		return block;
 	}
+}
+
+/**
+ *
+ * @param html
+ */
+function fallbackBlockData(html: string): BlockData {
+	return {
+		name: 'text',
+		containerProps: {
+			type: 'grid',
+			columns: 1,
+		},
+		classList: [],
+		items: [[{ name: 'wysiwyg', data: { wysiwyg: html } }]],
+	};
 }
 
 /**

--- a/packages/@burger-editor/core/src/editable-content.spec.ts
+++ b/packages/@burger-editor/core/src/editable-content.spec.ts
@@ -12,6 +12,9 @@ function createMockEngine() {
 	return {
 		isProcessed: false,
 		save: vi.fn(),
+		createFallbackBlockFromHTML: vi.fn().mockResolvedValue({
+			el: document.createElement('div'),
+		}),
 		restoreBlockFromElement: vi.fn().mockResolvedValue({
 			el: document.createElement('div'),
 		}),
@@ -178,6 +181,20 @@ describe('EditableContent', () => {
 			content.setContentsAsDOM(newEl);
 
 			expect(content.containerElement.contains(newEl)).toBe(true);
+		});
+	});
+
+	describe('static new', () => {
+		test('should build a fallback block from raw HTML with no block markers, without replacing containerElement itself', async () => {
+			const { host, containerElement } = createFakeHost();
+			const engine = createMockEngine();
+
+			const content = await EditableContent.new('main', '<p>hello</p>', engine, host);
+
+			expect(engine.createFallbackBlockFromHTML).toHaveBeenCalledWith('<p>hello</p>');
+			expect(engine.restoreBlockFromElement).not.toHaveBeenCalled();
+			expect(content.containerElement).toBe(containerElement);
+			expect(document.body.contains(content.containerElement)).toBe(true);
 		});
 	});
 

--- a/packages/@burger-editor/core/src/editable-content.ts
+++ b/packages/@burger-editor/core/src/editable-content.ts
@@ -89,13 +89,14 @@ export class EditableContent<T extends EditableAreaType = 'main'> {
 	}
 
 	async #init() {
+		const contentString = this.getContentsAsString();
 		if (
-			!this.isEmpty() &&
+			contentString !== '' &&
 			this.containerElement.querySelectorAll(
 				'[data-bge-name], [data-bgb], .bgb-container, .bg-editor-block-container, .cb-editor-block-container',
 			).length === 0
 		) {
-			const block = await this.#engine.restoreBlockFromElement(this.containerElement);
+			const block = await this.#engine.createFallbackBlockFromHTML(contentString);
 			this.setContentsAsDOM(block.el);
 		} else {
 			for (const el of this.containerElement.children) {

--- a/packages/@burger-editor/core/src/engine/copy-editable-area.spec.ts
+++ b/packages/@burger-editor/core/src/engine/copy-editable-area.spec.ts
@@ -13,6 +13,9 @@ function createMockEngine() {
 	return {
 		isProcessed: false,
 		save: vi.fn(),
+		createFallbackBlockFromHTML: vi.fn().mockResolvedValue({
+			el: document.createElement('div'),
+		}),
 		restoreBlockFromElement: vi.fn().mockResolvedValue({
 			el: document.createElement('div'),
 		}),
@@ -37,7 +40,7 @@ function createAreas(mainContent: string, draftContent: string) {
 }
 
 // data-bgb付きのブロック形式にしないとEditableContentの#initが
-// 「ブロック無しコンテンツ」とみなしrestoreBlockFromElement（モック）の
+// 「ブロック無しコンテンツ」とみなしcreateFallbackBlockFromHTML（モック）の
 // 戻り値でコンテンツを置換してしまう
 const MAIN_CONTENT = '<div data-bgb="text"><p>本稿</p></div>';
 const DRAFT_CONTENT = '<div data-bgb="text"><p>下書き</p></div>';

--- a/packages/@burger-editor/core/src/engine/engine.spec.ts
+++ b/packages/@burger-editor/core/src/engine/engine.spec.ts
@@ -52,6 +52,40 @@ describe('BurgerEditorEngine.new', () => {
 		expect(engine.content.getContentsAsString()).toBe(MINIMAL_BLOCK_CONTENT);
 	});
 
+	test('ブロックマーカーを一つも持たない生HTMLを渡してもcontainerElementがviewArea配下に残り続ける（#838回帰）', async () => {
+		const engine = await BurgerEditorEngine.new(
+			createOptions({
+				initialContents: '<p>hello</p>',
+				items: {
+					wysiwyg: {
+						version: '1',
+						name: 'wysiwyg',
+						template: '<div data-bge="wysiwyg"><p>placeholder</p></div>',
+						style: '',
+					},
+				},
+			}),
+		);
+
+		const container = engine.viewArea.querySelector<HTMLElement>(
+			'[data-bge-component="editable-area"]',
+		);
+		expect(container).not.toBeNull();
+		expect(engine.content.containerElement).toBe(container);
+		expect(container?.isConnected).toBe(true);
+
+		const fallbackBlock = engine.content.containerElement.querySelector(
+			'[data-bge-name="text"]',
+		);
+		expect(fallbackBlock).not.toBeNull();
+
+		// containerElement.outerHTMLではなくinnerHTMLが使われ、余分なラップなしで
+		// 元コンテンツがそのままwysiwygアイテムに渡っていることを確認する
+		const wysiwygEl =
+			engine.content.containerElement.querySelector('[data-bge="wysiwyg"]');
+		expect(wysiwygEl?.innerHTML).toBe('<p>hello</p>');
+	});
+
 	test('cleanUp()でフォールバックviewが生成したコンテナが除去される', async () => {
 		const engine = await BurgerEditorEngine.new(createOptions());
 		const container = engine.viewArea.querySelector(

--- a/packages/@burger-editor/core/src/engine/engine.ts
+++ b/packages/@burger-editor/core/src/engine/engine.ts
@@ -163,6 +163,19 @@ export class BurgerEditorEngine {
 		this.#currentBlock = null;
 	}
 
+	/**
+	 * ブロックマーカーを持たない生HTMLを、1つのwysiwygアイテムとして
+	 * ラップしたフォールバックブロックに変換する
+	 * @param html 生HTML
+	 * @returns 生成されたフォールバックのBurgerBlock
+	 * @example
+	 * ```ts
+	 * const block = await engine.createFallbackBlockFromHTML('<p>hello</p>');
+	 * ```
+	 */
+	createFallbackBlockFromHTML(html: string) {
+		return BurgerBlock.createFallback(html, this.#createItemElement.bind(this));
+	}
 	async draftToMain(confirm?: ConfirmCallback) {
 		if (!this.#draft) {
 			return false;
@@ -263,7 +276,14 @@ export class BurgerEditorEngine {
 	/**
 	 * HTML要素からブロックを復元する
 	 * HTML要素から完全にBlockDefinitionを解析してブロック作成
-	 * @param element HTML要素
+	 *
+	 * `element`がburger blockと認識されない場合、`element`はその場でフォールバック
+	 * ブロックに置換される（DOM上の親からの参照は`element`のまま無効になる）。
+	 * そのため`element`には常にコンテナの子要素を渡すこと。コンテナ自身を渡すと、
+	 * コンテナがDOMツリーから切り離される（ブロックマーカーを持たない生HTMLを
+	 * 初期コンテンツとして扱いたい場合は代わりに{@link createFallbackBlockFromHTML}
+	 * を使う）
+	 * @param element ブロックの子要素として渡すHTML要素（コンテナ自身は不可）
 	 * @returns 復元されたBurgerBlock
 	 */
 	restoreBlockFromElement(element: HTMLElement) {


### PR DESCRIPTION
## 概要

- `EditableContent#init()` が、ブロックマーカーを一つも持たない生HTML（例: `<p>hello</p>`）を初期コンテンツとして受け取った際、`containerElement` 自身を `restoreBlockFromElement()`（内部的に `BurgerBlock.rebind`）に渡してしまい、フォールバック分岐の `el.replaceWith(fallbackEl)` によって **`containerElement` が実DOMツリーから切り離される** バグを修正
- 専用の構築パス `BurgerBlock.createFallback()` / `engine.createFallbackBlockFromHTML()` を新設し、`containerElement` の innerHTML をそのままフォールバックブロックの wysiwyg データとして使うことで、コンテナ自体を置換対象にしない

## 背景

PR #837（core/client の view port 境界再設計）の QA レビュー中、`BurgerEditorEngine.new()` を実際に呼び出す統合テストを新規に書いた際に発覚（issue #838）。既存テストは `restoreBlockFromElement` を常にモックしていたため、このフォールバック経路が実行されたことが一度もなく、リグレッションとして検出されずに残っていた。

バグ自体は #837 のリファクタが原因ではなく、以前から存在する（前身の `editable-area.ts` にも同一ロジックがあった）。

## 変更内容

- `packages/@burger-editor/core/src/block/block.ts`
  - `#fallbackBlockData` をモジュールレベル関数 `fallbackBlockData` に切り出し
  - 新規 `static BurgerBlock.createFallback(html, createItemElement)` を追加（既存の `#rebind()` の「置換」契約は変更しない）
- `packages/@burger-editor/core/src/engine/engine.ts`
  - 新規 `createFallbackBlockFromHTML(html)` を追加（`BurgerBlock.createFallback` への薄いラッパー）
  - `restoreBlockFromElement()` の JSDoc に「`element` には常にコンテナの子要素を渡すこと（コンテナ自身は不可）」という前提条件を明記
- `packages/@burger-editor/core/src/editable-content.ts`
  - `#init()` のフォールバック分岐で `restoreBlockFromElement(this.containerElement)` の代わりに `createFallbackBlockFromHTML(contentString)` を使うよう変更
- テスト追加
  - `engine.spec.ts`: 非モックの統合テストで `containerElement` がviewArea配下に残り続け、かつコンテンツが余分なラップなしで正しく保持されることを検証
  - `editable-content.spec.ts`: `createFallbackBlockFromHTML` が正しい引数で呼ばれ、`restoreBlockFromElement` は呼ばれないことを検証
  - `copy-editable-area.spec.ts`: モックエンジンに新APIを追加（既存コメントの更新含む）

## テスト

- `yarn lint` — 0 エラー（既存の警告4件は本PRと無関係な別ファイル由来）
- `yarn build` — 成功
- `yarn test:unit --project core` — 220 テスト全通過
- `yarn test`（Docker、VR含む） — `core` パッケージは全通過。`local`/`client` パッケージの一部テストがフルスイート実行時に環境依存でフレークしたが、該当ファイルを単体実行するといずれも全通過しており、本PRの変更とは無関係と判断

## 関連

- Closes #838
- 関連: #837
