### PR TITLE
docs(client): rename fileAPI option to fileIO in README

### DIFF
--- a/packages/@burger-editor/client/README.md
+++ b/packages/@burger-editor/client/README.md
@@ -63,7 +63,7 @@ const { engine } = await createBurgerEditorClient({
 | `blocks`            | `BlockDefinition[]`                                       | カスタムブロック定義                           |
 | `storageKey`        | `{ blockClipboard?: string; ... }`                        | ストレージキー設定（ブロッククリップボード等） |
 | `onUpdated`         | `(main: string, draft?: string) => void \| Promise<void>` | コンテンツ更新時のコールバック                 |
-| `fileAPI`           | `FileAPI`                                                 | ファイル I/O API 実装（後述）                  |
+| `fileIO`            | `FileAPI`                                                 | ファイル I/O API 実装（後述）                  |
 | `healthCheck`       | `HealthCheckOptions`                                      | ヘルスチェックの設定                           |
 | `experimental`      | `ExperimentalOptions`                                     | 実験的機能の設定                               |
 
@@ -101,12 +101,12 @@ const stylesheets = engine.config.stylesheets;
 
 ## `FileAPI` の実装例
 
-ファイルアップロード機能を有効にする場合、`fileAPI` プロパティに以下のインタフェースを満たす実装を渡す。各メソッドはすべて optional で、提供したメソッドに対応する UI 機能（ファイル一覧表示・アップロード・削除）だけが有効になる。
+ファイルアップロード機能を有効にする場合、`fileIO` プロパティに以下のインタフェースを満たす実装を渡す。各メソッドはすべて optional で、提供したメソッドに対応する UI 機能（ファイル一覧表示・アップロード・削除）だけが有効になる。
 
 ```ts
 import type { FileAPI } from '@burger-editor/core';
 
-const fileAPI: FileAPI = {
+const fileIO: FileAPI = {
 	async getFileList(fileType, options) {
 		const res = await fetch(`/api/files/${fileType}?page=${options.page}`);
 		return res.json();


### PR DESCRIPTION
## 概要

`packages/@burger-editor/client/README.md` の `createBurgerEditorClient` オプション名の誤記を修正。

`BurgerEditorEngineOptions` の実際のフィールド名は `fileIO`（`packages/@burger-editor/core/src/types.ts`）だが、README では `fileAPI` と誤って記載されていた。README の例をそのまま `fileAPI` で渡すと、ファイルアップロード等の機能が有効化されない。

## 変更内容

- 「任意プロパティ」表の項目名: `fileAPI` → `fileIO`
- `FileAPI` の実装例セクションの説明文: `fileAPI` → `fileIO`
- サンプルコードの変数名: `const fileAPI: FileAPI = {...}` → `const fileIO: FileAPI = {...}`

型名 `FileAPI`（インタフェース名）自体は変更なし。オプションのキー名のみ修正。

## 経緯

PR #837 の product-manager レビュー中に発見し、スコープ外のため issue #839 として起票していたもの。

Closes #839

## 補足

PR プリフライトの `yarn test` 実行中、本変更とは無関係な既存の flaky テスト（`server.spec.ts` の CLI 起動タイムアウト、フルスイート Docker 実行時のみ発生）を発見したため issue #841 として別途起票済み。

## テスト計画

- [x] `yarn lint`
- [x] `NX_WORKSPACE_ROOT_PATH=<worktree> yarn build`
- [x] `yarn test`（issue #841 の既知 flaky テスト以外は全てパス）
