### PR TITLE
test(local): raise server.spec.ts CLI-exit timeout and log actual duration

### DIFF
--- a/packages/@burger-editor/local/src/commands/server.spec.ts
+++ b/packages/@burger-editor/local/src/commands/server.spec.ts
@@ -29,10 +29,13 @@ type CliResult = {
  * signals. {@link tsxCli} lets us run the source `.ts` entry without first
  * building, so the test stays self-contained.
  * @param cwd
- * @param timeoutMs
+ * @param timeoutMs Defaults to 20_000ms — generous enough to absorb tsx's
+ *   cold-start compile cost under Docker/QEMU CPU contention with the other
+ *   projects' concurrently-running Playwright browser instances (#841).
  */
-function runCli(cwd: string, timeoutMs = 8000): Promise<CliResult> {
+function runCli(cwd: string, timeoutMs = 20_000): Promise<CliResult> {
 	return new Promise<CliResult>((resolve, reject) => {
+		const startedAt = Date.now();
 		const child: ChildProcess = spawn(process.execPath, [tsxCli, cliEntry], {
 			cwd,
 			env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
@@ -52,6 +55,14 @@ function runCli(cwd: string, timeoutMs = 8000): Promise<CliResult> {
 		}, timeoutMs);
 		child.on('exit', (code, signal) => {
 			clearTimeout(timer);
+			// Logged unconditionally (not just on near-timeout runs) so CI
+			// history builds a real latency distribution for this spawn+tsx
+			// path. Without it, a future timeout (#841) only tells us "> N
+			// ms", never how much margin was actually needed.
+			// eslint-disable-next-line no-console
+			console.info(
+				`[server.spec] runCli(${cwd}) exited in ${Date.now() - startedAt}ms (code=${code}, signal=${signal})`,
+			);
 			resolve({ code, signal, stdout, stderr });
 		});
 		child.on('error', (error) => {
@@ -112,7 +123,7 @@ describe('runServerCommand boot (virtualTree)', () => {
 		// stack frames) must not be the source of the output.
 		expect(result.stderr).not.toContain('PathConflictError:');
 		expect(result.stderr).not.toMatch(/^\s+at\s/m);
-	}, 15_000);
+	}, 25_000);
 
 	test('exits 1 with file name when a frontmatter pathKey is missing (regression: #754)', async () => {
 		await fs.writeFile(
@@ -136,5 +147,5 @@ describe('runServerCommand boot (virtualTree)', () => {
 		expect(result.code).toBe(1);
 		expect(result.stderr).toContain('Failed to load virtualTree resolver state');
 		expect(result.stderr).toContain('7.html');
-	}, 15_000);
+	}, 25_000);
 });


### PR DESCRIPTION
## 概要

`packages/@burger-editor/local/src/commands/server.spec.ts` の `runServerCommand boot (virtualTree)` 系テストが、`yarn test`（Docker 経由のフルスイート実行）で時折 `CLI did not exit within 8000ms` で失敗する問題（#841）を修正します。

## 原因

`runCli()` の子プロセス起動（tsx 経由での TypeScript ソース実行）が、Docker（QEMU エミュレーション込み）＋他プロジェクト（`core` / `custom-element` / `blocks` / `vr`）が同時に Playwright ブラウザインスタンスを起動する負荷下で、ハードコードされた 8000ms を超えることがありました。

## 対応内容

- `runCli()` のデフォルト `timeoutMs` を 8000ms → 20000ms に引き上げ、対応する2つの `test()` のタイムアウトも 15000ms → 25000ms に引き上げ
- `runCli()` に開始時刻の計測を追加し、プロセス終了時に実際の所要時間を `console.info` でログ出力するようにしました。次回 flaky が発生した際に「8000ms を超えた」という二値情報ではなく、実測データを CI ログから得られるようにするためです

## 検証

- `NX_WORKSPACE_ROOT_PATH` を指定した worktree 内で `yarn build` → `yarn test`（Docker 経由フルスイート）を実行し、全90ファイル・984テストがパスすることを確認
- 追加したログにより、該当テストの実測所要時間が **8734ms**（旧タイムアウト値 8000ms を実際に超過）であることを確認し、今回の引き上げが有効であることを実データで裏付け

## 関連

- Closes #841
